### PR TITLE
Fix a bug that .py files aren't included in package

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,50 @@
+# Copyright 2026 Enactic, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Test
+on:
+  push:
+    branches-ignore:
+      - 'copilot/**'
+      - 'dependabot/**'
+    tags:
+      - '**'
+  pull_request:
+concurrency:
+  group: ${{ github.head_ref || github.sha }}-${{ github.workflow }}
+  cancel-in-progress: true
+jobs:
+  install:
+    name: Install
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    strategy:
+      fail-fast: false
+      matrix:
+        install-options:
+          - ""
+          - "-e"
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.x'
+      - name: Install
+        run: |
+          pip install ${{ matrix.install-options }} .
+      - name: Test
+        run: |
+          set -x
+          path=$(python -c 'from openarm_mujoco.v2 import openarm_cell_xml; print(openarm_cell_xml())')
+          [ -f "${path}" ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,13 +54,6 @@ extend-select = [
 
 [tool.setuptools.package-dir]
 "" = "src"
-"openarm_mujoco.v2" = "v2"
 
 [tool.setuptools.packages.find]
 where = ["src"]
-
-[tool.setuptools.package-data]
-"openarm_mujoco.v2" = [
-    "*.xml",
-    "assets/**/*",
-]

--- a/setup.py
+++ b/setup.py
@@ -41,15 +41,16 @@ def _data_files() -> list[tuple[str, list[str]]]:
                 continue
             if path.suffix.lower() not in _ALLOWED_SUFFIXES:
                 continue
-            if any(part.startswith(".") or part in _EXCLUDED_PARTS for part in path.parts):
+            if any(
+                part.startswith(".") or part in _EXCLUDED_PARTS for part in path.parts
+            ):
                 continue
 
             target = Path("share") / "openarm_mujoco" / path.parent
             files_by_target[str(target)].append(str(path))
 
     return [
-        (target, sorted(files))
-        for target, files in sorted(files_by_target.items())
+        (target, sorted(files)) for target, files in sorted(files_by_target.items())
     ]
 
 

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,17 @@
-import re
+# Copyright 2026 Enactic, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from collections import defaultdict
 from pathlib import Path
 
@@ -6,7 +19,7 @@ from setuptools import setup
 
 
 _PROJECT_ROOT = Path(__file__).resolve().parent
-_VERSION_DIR_PATTERN = re.compile(r"v\d+(?:\.\d+)*$")
+_BUNDLED_VERSION_DIRS = ("v2",)
 _EXCLUDED_PARTS = {
     ".venv",
     "__pycache__",
@@ -26,11 +39,11 @@ _ALLOWED_SUFFIXES = {
 
 
 def _version_dirs() -> list[Path]:
-    return sorted(
+    return [
         path
-        for path in _PROJECT_ROOT.iterdir()
-        if path.is_dir() and _VERSION_DIR_PATTERN.fullmatch(path.name)
-    )
+        for version_dir in _BUNDLED_VERSION_DIRS
+        if (path := _PROJECT_ROOT / version_dir).is_dir()
+    ]
 
 
 def _data_files() -> list[tuple[str, list[str]]]:

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,56 @@
+import re
+from collections import defaultdict
+from pathlib import Path
+
+from setuptools import setup
+
+
+_VERSION_DIR_PATTERN = re.compile(r"v\d+(?:\.\d+)*$")
+_EXCLUDED_PARTS = {
+    ".venv",
+    "__pycache__",
+    "openarm_mujoco.egg-info",
+    "openarm_mujoco_v2",
+}
+_ALLOWED_SUFFIXES = {
+    ".jpeg",
+    ".jpg",
+    ".mjcf",
+    ".mtl",
+    ".obj",
+    ".png",
+    ".stl",
+    ".xml",
+}
+
+
+def _version_dirs() -> list[Path]:
+    return sorted(
+        path
+        for path in Path(".").iterdir()
+        if path.is_dir() and _VERSION_DIR_PATTERN.fullmatch(path.name)
+    )
+
+
+def _data_files() -> list[tuple[str, list[str]]]:
+    files_by_target: dict[str, list[str]] = defaultdict(list)
+
+    for root in _version_dirs():
+        for path in root.rglob("*"):
+            if not path.is_file():
+                continue
+            if path.suffix.lower() not in _ALLOWED_SUFFIXES:
+                continue
+            if any(part.startswith(".") or part in _EXCLUDED_PARTS for part in path.parts):
+                continue
+
+            target = Path("share") / "openarm_mujoco" / path.parent
+            files_by_target[str(target)].append(str(path))
+
+    return [
+        (target, sorted(files))
+        for target, files in sorted(files_by_target.items())
+    ]
+
+
+setup(data_files=_data_files())

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from setuptools import setup
 
 
+_PROJECT_ROOT = Path(__file__).resolve().parent
 _VERSION_DIR_PATTERN = re.compile(r"v\d+(?:\.\d+)*$")
 _EXCLUDED_PARTS = {
     ".venv",
@@ -27,7 +28,7 @@ _ALLOWED_SUFFIXES = {
 def _version_dirs() -> list[Path]:
     return sorted(
         path
-        for path in Path(".").iterdir()
+        for path in _PROJECT_ROOT.iterdir()
         if path.is_dir() and _VERSION_DIR_PATTERN.fullmatch(path.name)
     )
 
@@ -41,13 +42,15 @@ def _data_files() -> list[tuple[str, list[str]]]:
                 continue
             if path.suffix.lower() not in _ALLOWED_SUFFIXES:
                 continue
+            relative_path = path.relative_to(_PROJECT_ROOT)
             if any(
-                part.startswith(".") or part in _EXCLUDED_PARTS for part in path.parts
+                part.startswith(".") or part in _EXCLUDED_PARTS
+                for part in relative_path.parts
             ):
                 continue
 
-            target = Path("share") / "openarm_mujoco" / path.parent
-            files_by_target[str(target)].append(str(path))
+            target = Path("share") / "openarm_mujoco" / relative_path.parent
+            files_by_target[str(target)].append(str(relative_path))
 
     return [
         (target, sorted(files)) for target, files in sorted(files_by_target.items())

--- a/src/openarm_mujoco/v2/__init__.py
+++ b/src/openarm_mujoco/v2/__init__.py
@@ -18,15 +18,23 @@ from .joint_resolver import JointResolver as JointResolver
 
 
 def asset_path(relative: str) -> str:
-    """Return an absolute filesystem path to an asset inside this package.
+    """Return an absolute filesystem path to a v2 MJCF asset.
 
     Example: asset_path("openarm_bimanual.xml")
     """
-    from importlib.resources import files
+    import sysconfig
     from pathlib import Path
 
-    p = files("openarm_mujoco.v2").joinpath(relative)
-    return str(Path(p))
+    current_file = Path(__file__).resolve()
+    for parent in current_file.parents:
+        source_tree_path = parent / "v2" / relative
+        if source_tree_path.exists():
+            return str(source_tree_path)
+
+    installed_path = (
+        Path(sysconfig.get_path("data")) / "share" / "openarm_mujoco" / "v2" / relative
+    )
+    return str(installed_path)
 
 
 def openarm_bimanual_paths() -> list[str]:

--- a/src/openarm_mujoco/v2/__init__.py
+++ b/src/openarm_mujoco/v2/__init__.py
@@ -14,27 +14,63 @@
 
 """Provide MuJoCo related files and convenient utilities."""
 
+import sysconfig
+from pathlib import Path
+
 from .joint_resolver import JointResolver as JointResolver
+
+
+def _resolve_asset_path(root: Path, relative: str) -> Path:
+    relative_path = Path(relative)
+    if relative_path.is_absolute():
+        msg = f"Asset path must be relative: {relative}"
+        raise ValueError(msg)
+
+    root = root.resolve()
+    path = (root / relative_path).resolve()
+    try:
+        path.relative_to(root)
+    except ValueError as exc:
+        msg = f"Asset path must stay within asset root: {relative}"
+        raise ValueError(msg) from exc
+
+    return path
+
+
+def _source_tree_asset_root() -> Path | None:
+    current_file = Path(__file__).resolve()
+    for parent in current_file.parents:
+        if not (parent / "pyproject.toml").is_file():
+            continue
+
+        source_package_file = parent / "src" / "openarm_mujoco" / "v2" / "__init__.py"
+        if current_file != source_package_file.resolve():
+            continue
+
+        asset_root = parent / "v2"
+        if asset_root.is_dir():
+            return asset_root
+
+        return None
+
+    return None
 
 
 def asset_path(relative: str) -> str:
     """Return an absolute filesystem path to a v2 MJCF asset.
 
-    Example: asset_path("openarm_bimanual.xml")
+    Example: asset_path("openarm_v20_bimanual.xml")
     """
-    import sysconfig
-    from pathlib import Path
-
-    current_file = Path(__file__).resolve()
-    for parent in current_file.parents:
-        source_tree_path = parent / "v2" / relative
+    source_tree_root = _source_tree_asset_root()
+    if source_tree_root is not None:
+        source_tree_path = _resolve_asset_path(source_tree_root, relative)
         if source_tree_path.exists():
             return str(source_tree_path)
 
-    installed_path = (
-        Path(sysconfig.get_path("data")) / "share" / "openarm_mujoco" / "v2" / relative
+    installed_root = (
+        Path(sysconfig.get_path("data")) / "share" / "openarm_mujoco" / "v2"
     )
-    return str(installed_path)
+    return str(_resolve_asset_path(installed_root, relative))
 
 
 def openarm_bimanual_paths() -> list[str]:

--- a/src/openarm_mujoco/v2/__init__.py
+++ b/src/openarm_mujoco/v2/__init__.py
@@ -39,19 +39,14 @@ def _resolve_asset_path(root: Path, relative: str) -> Path:
 
 def _source_tree_asset_root() -> Path | None:
     current_file = Path(__file__).resolve()
-    for parent in current_file.parents:
-        if not (parent / "pyproject.toml").is_file():
-            continue
-
-        source_package_file = parent / "src" / "openarm_mujoco" / "v2" / "__init__.py"
-        if current_file != source_package_file.resolve():
-            continue
-
-        asset_root = parent / "v2"
-        if asset_root.is_dir():
-            return asset_root
-
+    source_root = current_file.parent.parent.parent.parent
+    source_package_file = source_root / "src" / "openarm_mujoco" / "v2" / "__init__.py"
+    if current_file != source_package_file.resolve():
         return None
+
+    asset_root = source_root / "v2"
+    if asset_root.is_dir():
+        return asset_root
 
     return None
 


### PR DESCRIPTION
This pull request refactors how MJCF asset files are located and packaged for the `openarm_mujoco` project, particularly for the `v2` assets. The main changes involve updating the asset discovery logic to work both in development and after installation, and restructuring the way data files are included in the package. This makes asset management more robust and flexible, especially for versioned directories.

**Packaging and asset management improvements:**

* Added a new data files discovery mechanism in `setup.py` that automatically collects asset files (with specific extensions) from versioned directories (e.g., `v2`, `v3`, etc.) and installs them under `share/openarm_mujoco/`, replacing the previous static configuration in `pyproject.toml`.
* Removed the explicit `package-dir` and `package-data` configuration for `openarm_mujoco.v2` in `pyproject.toml`, delegating asset inclusion to the new dynamic logic in `setup.py`.

**Asset path resolution logic:**

* Updated the `asset_path` function in `src/openarm_mujoco/v2/__init__.py` to first look for assets in the source tree (useful during development), and if not found, fall back to the installed location under `share/openarm_mujoco/v2/`. This replaces the previous use of `importlib.resources` for asset lookup.