### PR TITLE
Add task scenes for the v2 model: insertion, articulated objects, ball balance

### DIFF
--- a/v2/articulated_scene.xml
+++ b/v2/articulated_scene.xml
@@ -1,13 +1,23 @@
 <!--
 Copyright 2026 Enactic, Inc.
-Licensed under the Apache License, Version 2.0 (the "License").
-Articulated-object scene (Phase F1c): three authored articulated fixtures on a
-table for the OpenArm to operate -- a sliding DRAWER (prismatic joint), a hinged
-cabinet DOOR (revolute joint), and a turnable VALVE (revolute joint). Each has a
-graspable handle and both-arm grasp welds. Authored from scratch (no external
-mesh download) so the joints, ranges and handles are fully controllable. The
-articulated-manipulation skills (open drawer/door, turn valve) are built on this
-in phase S3; this scene + its physics-only test only establish the assets.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<!--
+Articulated objects: a sliding drawer (prismatic) and a hinged cabinet door
+(revolute) on a table, each with a graspable handle and inactive grasp welds
+for either arm. (The turnable valve lives in valve_scene.xml.)
 -->
 <mujoco model="openarm_v20_articulated">
   <compiler meshdir="assets" angle="radian"/>
@@ -25,10 +35,10 @@ in phase S3; this scene + its physics-only test only establish the assets.
   </default>
 
   <statistic center="0.30 0 0.55" extent="1.2" meansize="0.05"/>
-  <option timestep="0.002"/>
+  <option timestep="0.001"/>
 
   <visual>
-    <headlight diffuse="0.6 0.6 0.6" ambient="0.4 0.4 0.4" specular="0 0 0"/>
+    <headlight diffuse="0.6 0.6 0.6" ambient="0.3 0.3 0.3" specular="0 0 0"/>
     <rgba haze="0.15 0.25 0.35 1"/>
     <global azimuth="150" elevation="-20"/>
     <quality shadowsize="8192"/>
@@ -61,15 +71,22 @@ in phase S3; this scene + its physics-only test only establish the assets.
       <attach model="bimanual" prefix=""/>
     </frame>
 
-    <!-- Table: top at z=0.40. -->
-    <body name="table" pos="0.30 -0.02 0.36">
-      <geom name="table_top" type="box" size="0.24 0.32 0.04" rgba="0.82 0.71 0.55 1"
+    <!-- Table: top at z=0.40, centered on the arm (y=0). Footprint matches the
+         cell workspace table in cell.xml (0.41 x 0.55 half-extents) so tabletop
+         layouts carry over; the cell mounts the arms on a lifter above the
+         table, so absolute heights differ. -->
+    <body name="table" pos="0.47 0.0 0.36">
+      <geom name="table_top" type="box" size="0.41 0.55 0.04" rgba="0.82 0.71 0.55 1"
             friction="1 0.005 0.0001" contype="1" conaffinity="1"/>
     </body>
 
     <!-- DRAWER: a fixed cabinet shell (opening faces -x, toward the robot) with a
          drawer that slides out toward the robot; horizontal handle bar in front. -->
-    <body name="cabinet_drawer" pos="0.36 -0.22 0.40">
+    <body name="cabinet_drawer" pos="0.50 -0.26 0.46">
+      <!-- Solid base raises the drawer slot to a comfortable operating height
+           (handle ~10 cm above the table) so a frontal, human-like grasp has
+           clearance under the wrist. -->
+      <geom name="drawer_base"   class="fixture" size="0.05 0.055 0.03" pos="0 0 -0.03"/>
       <geom name="drawer_bottom" class="fixture" size="0.05 0.055 0.005" pos="0 0 0.005"/>
       <geom name="drawer_top"    class="fixture" size="0.05 0.055 0.005" pos="0 0 0.105"/>
       <geom name="drawer_back"   class="fixture" size="0.005 0.055 0.05" pos="0.05 0 0.055"/>
@@ -79,30 +96,24 @@ in phase S3; this scene + its physics-only test only establish the assets.
         <joint name="drawer_slide" type="slide" axis="1 0 0" range="-0.10 0" damping="1" frictionloss="0.05"/>
         <geom name="drawer_box"    type="box" size="0.038 0.038 0.03" pos="0 0 0" mass="0.20" friction="0.4 0.01 0.01" rgba="0.30 0.45 0.62 1" contype="1" conaffinity="1"/>
         <geom name="drawer_front"  type="box" size="0.006 0.04 0.028" pos="-0.046 0 0" mass="0.05" friction="0.4 0.01 0.01" rgba="0.22 0.36 0.52 1" contype="1" conaffinity="1"/>
-        <geom name="drawer_handle" type="cylinder" fromto="-0.066 -0.02 0 -0.066 0.02 0" size="0.007" mass="0.02" rgba="0.2 0.2 0.22 1" contype="1" conaffinity="1"/>
-      </body>
-    </body>
-
-    <!-- VALVE: a fixed pipe with a lever that turns about the vertical axis; grasp
-         the knob at the lever tip and sweep it in an arc. -->
-    <body name="valve_base" pos="0.26 -0.10 0.40">
-      <geom name="valve_pipe" class="fixture" type="cylinder" size="0.015 0.0275" pos="0 0 0.0275" rgba="0.4 0.4 0.45 1"/>
-      <body name="valve" pos="0 0 0.065">
-        <joint name="valve_turn" type="hinge" axis="0 0 1" range="-3.0 3.0" damping="0.5" frictionloss="0.05"/>
-        <geom name="valve_hub"   type="cylinder" fromto="0 0 -0.006 0 0 0.006" size="0.014" mass="0.05" rgba="0.3 0.3 0.35 1" contype="1" conaffinity="1"/>
-        <geom name="valve_lever" type="box" size="0.035 0.008 0.006" pos="0.035 0 0" mass="0.05" rgba="0.7 0.2 0.2 1" contype="1" conaffinity="1"/>
-        <geom name="valve_grip"  type="cylinder" fromto="0.062 0 -0.02 0.062 0 0.02" size="0.007" mass="0.02" rgba="0.2 0.2 0.22 1" contype="1" conaffinity="1"/>
+        <!-- Handle bar stands 4 cm proud of the front panel on two stems so a
+             gripper's finger pads can close around the bar without touching
+             the panel. -->
+        <geom name="drawer_handle"      type="cylinder" fromto="-0.092 -0.02 0 -0.092 0.02 0" size="0.007" mass="0.02" rgba="0.2 0.2 0.22 1" contype="1" conaffinity="1"/>
+        <geom name="drawer_handle_stem1" type="cylinder" fromto="-0.052 -0.018 0 -0.092 -0.018 0" size="0.004" mass="0.005" rgba="0.2 0.2 0.22 1" contype="1" conaffinity="1"/>
+        <geom name="drawer_handle_stem2" type="cylinder" fromto="-0.052 0.018 0 -0.092 0.018 0" size="0.004" mass="0.005" rgba="0.2 0.2 0.22 1" contype="1" conaffinity="1"/>
       </body>
     </body>
 
     <!-- DOOR: a fixed post with a hinged panel that swings open about the vertical
          edge; vertical handle bar at the far edge. -->
-    <body name="cabinet_door" pos="0.29 0.13 0.40">
-      <geom name="door_post" class="fixture" size="0.01 0.01 0.06" pos="0 -0.07 0.06" rgba="0.4 0.4 0.45 1"/>
+    <body name="cabinet_door" pos="0.34 0.32 0.40">
+      <geom name="door_post" class="fixture" size="0.007 0.007 0.06" pos="0 -0.07 0.06" rgba="0.4 0.4 0.45 1"/>
       <body name="door" pos="0 -0.07 0.06">
         <joint name="door_hinge" type="hinge" axis="0 0 1" range="0 1.4" damping="0.2" frictionloss="0.02"/>
-        <geom name="door_panel"  type="box" size="0.006 0.06 0.05" pos="0 0.06 0" mass="0.08" rgba="0.55 0.45 0.3 1" contype="1" conaffinity="1"/>
-        <geom name="door_handle" type="cylinder" fromto="0 0.115 -0.02 0 0.115 0.02" size="0.007" mass="0.02" rgba="0.2 0.2 0.22 1" contype="1" conaffinity="1"/>
+        <!-- Panel offset from the hinge post so the swing never binds on it. -->
+        <geom name="door_panel"  type="box" size="0.006 0.06 0.05" pos="0 0.075 0" mass="0.08" rgba="0.55 0.45 0.3 1" contype="1" conaffinity="1"/>
+        <geom name="door_handle" type="cylinder" fromto="0 0.13 -0.02 0 0.13 0.02" size="0.007" mass="0.02" rgba="0.2 0.2 0.22 1" contype="1" conaffinity="1"/>
       </body>
     </body>
   </worldbody>
@@ -110,19 +121,20 @@ in phase S3; this scene + its physics-only test only establish the assets.
   <equality>
     <weld name="grasp_right_drawer" body1="openarm_right_ee_base_link" body2="drawer" active="false" solref="0.02 1"/>
     <weld name="grasp_left_drawer"  body1="openarm_left_ee_base_link"  body2="drawer" active="false" solref="0.02 1"/>
-    <weld name="grasp_right_valve"  body1="openarm_right_ee_base_link" body2="valve"  active="false" solref="0.02 1"/>
-    <weld name="grasp_left_valve"   body1="openarm_left_ee_base_link"  body2="valve"  active="false" solref="0.02 1"/>
     <weld name="grasp_right_door"   body1="openarm_right_ee_base_link" body2="door"   active="false" solref="0.02 1"/>
     <weld name="grasp_left_door"    body1="openarm_left_ee_base_link"  body2="door"   active="false" solref="0.02 1"/>
   </equality>
 
   <keyframe>
-    <!-- nq = left arm(0-8) + right arm(9-17) + drawer(18) + valve(19) + door(20) = 21.
-         Both arms start raised and clear of the fixtures (left = joint mirror of right). -->
-    <key name="ready"
-      qpos="0.720369 -2.27095 -0.290977 1.90389 -1.23759 -0.785149 -0.558776 0 0
-            -0.720369 2.27095 0.290977 1.90389 1.23759 0.785149 0.558776 0 0
-            0 0 0"/>
+    <!-- nq = left arm(0-8) + right arm(9-17) + drawer(18) + door(19) = 20.
+         Arms at the shared "home" pose (same as pedestal.xml, with ctrl set so
+         the position actuators hold it); fixtures closed. -->
+    <key name="home"
+      qpos="0.0 0.0 0.0 1.570796 0.0 0.0 0.0 0.0 0.0
+            0.0 0.0 0.0 1.570796 0.0 0.0 0.0 0.0 0.0
+            0 0"
+      ctrl="0 0 0 1.570796 0 0 0 0
+            0 0 0 1.570796 0 0 0 0"/>
   </keyframe>
 
 </mujoco>

--- a/v2/articulated_scene.xml
+++ b/v2/articulated_scene.xml
@@ -1,0 +1,128 @@
+<!--
+Copyright 2026 Enactic, Inc.
+Licensed under the Apache License, Version 2.0 (the "License").
+Articulated-object scene (Phase F1c): three authored articulated fixtures on a
+table for the OpenArm to operate -- a sliding DRAWER (prismatic joint), a hinged
+cabinet DOOR (revolute joint), and a turnable VALVE (revolute joint). Each has a
+graspable handle and both-arm grasp welds. Authored from scratch (no external
+mesh download) so the joints, ranges and handles are fully controllable. The
+articulated-manipulation skills (open drawer/door, turn valve) are built on this
+in phase S3; this scene + its physics-only test only establish the assets.
+-->
+<mujoco model="openarm_v20_articulated">
+  <compiler meshdir="assets" angle="radian"/>
+
+  <default>
+    <default class="visual">
+      <geom contype="0" conaffinity="0" group="2"/>
+    </default>
+    <default class="collision">
+      <geom condim="3" conaffinity="1" priority="1" group="3" solref="0.005 1" friction="1 0.01 0.01"/>
+    </default>
+    <default class="fixture">
+      <geom type="box" contype="1" conaffinity="1" friction="1 0.01 0.01" rgba="0.55 0.45 0.32 1"/>
+    </default>
+  </default>
+
+  <statistic center="0.30 0 0.55" extent="1.2" meansize="0.05"/>
+  <option timestep="0.002"/>
+
+  <visual>
+    <headlight diffuse="0.6 0.6 0.6" ambient="0.4 0.4 0.4" specular="0 0 0"/>
+    <rgba haze="0.15 0.25 0.35 1"/>
+    <global azimuth="150" elevation="-20"/>
+    <quality shadowsize="8192"/>
+  </visual>
+
+  <asset>
+    <texture type="skybox" builtin="gradient" rgb1="0.55 0.55 0.58" rgb2="0.2 0.2 0.2" width="512" height="3072"/>
+    <texture type="2d" name="groundplane" builtin="checker" mark="edge" rgb1="0.38 0.38 0.4" rgb2="0.3 0.3 0.32"
+      markrgb="0.6 0.6 0.6" width="300" height="300"/>
+    <material name="groundplane" texture="groundplane" texuniform="true" texrepeat="5 5" reflectance="0.2"/>
+
+    <material name="openarm_body_link0_material" rgba="0.247 0.247 0.247 1.0" reflectance="0.05" shininess="0.5"/>
+    <mesh name="body_link0"      content_type="model/stl" file="visual/body/body_link0.stl"     scale="0.001 0.001 0.001"/>
+    <mesh name="body_link0_symp" content_type="model/stl" file="collision/body_link0_symp.stl" scale="0.001 0.001 0.001"/>
+
+    <model name="bimanual" file="openarm_bimanual.xml"/>
+  </asset>
+
+  <worldbody>
+    <light pos="0 0 2" dir="0 0 -1" directional="true"/>
+    <geom name="floor" size="0 0 0.05" type="plane" material="groundplane"/>
+
+    <camera name="tablecam" pos="0.30 0.0 1.30" xyaxes="1 0 0 0 1 0" fovy="60"/>
+    <camera name="frontcam" pos="1.05 0.0 0.90" xyaxes="0 -1 0 0.3 0 1" fovy="55"/>
+
+    <geom name="openarm_body_link0_visual"    type="mesh" mesh="body_link0"      class="visual"    material="openarm_body_link0_material"/>
+    <geom name="openarm_body_link0_collision" type="mesh" mesh="body_link0_symp" class="collision"/>
+
+    <frame pos="0 0 0.698">
+      <attach model="bimanual" prefix=""/>
+    </frame>
+
+    <!-- Table: top at z=0.40. -->
+    <body name="table" pos="0.30 -0.02 0.36">
+      <geom name="table_top" type="box" size="0.24 0.32 0.04" rgba="0.82 0.71 0.55 1"
+            friction="1 0.005 0.0001" contype="1" conaffinity="1"/>
+    </body>
+
+    <!-- DRAWER: a fixed cabinet shell (opening faces -x, toward the robot) with a
+         drawer that slides out toward the robot; horizontal handle bar in front. -->
+    <body name="cabinet_drawer" pos="0.36 -0.22 0.40">
+      <geom name="drawer_bottom" class="fixture" size="0.05 0.055 0.005" pos="0 0 0.005"/>
+      <geom name="drawer_top"    class="fixture" size="0.05 0.055 0.005" pos="0 0 0.105"/>
+      <geom name="drawer_back"   class="fixture" size="0.005 0.055 0.05" pos="0.05 0 0.055"/>
+      <geom name="drawer_sideL"  class="fixture" size="0.055 0.005 0.05" pos="0 0.05 0.055"/>
+      <geom name="drawer_sideR"  class="fixture" size="0.055 0.005 0.05" pos="0 -0.05 0.055"/>
+      <body name="drawer" pos="0 0 0.045">
+        <joint name="drawer_slide" type="slide" axis="1 0 0" range="-0.10 0" damping="1" frictionloss="0.05"/>
+        <geom name="drawer_box"    type="box" size="0.038 0.038 0.03" pos="0 0 0" mass="0.20" friction="0.4 0.01 0.01" rgba="0.30 0.45 0.62 1" contype="1" conaffinity="1"/>
+        <geom name="drawer_front"  type="box" size="0.006 0.04 0.028" pos="-0.046 0 0" mass="0.05" friction="0.4 0.01 0.01" rgba="0.22 0.36 0.52 1" contype="1" conaffinity="1"/>
+        <geom name="drawer_handle" type="cylinder" fromto="-0.066 -0.02 0 -0.066 0.02 0" size="0.007" mass="0.02" rgba="0.2 0.2 0.22 1" contype="1" conaffinity="1"/>
+      </body>
+    </body>
+
+    <!-- VALVE: a fixed pipe with a lever that turns about the vertical axis; grasp
+         the knob at the lever tip and sweep it in an arc. -->
+    <body name="valve_base" pos="0.26 -0.10 0.40">
+      <geom name="valve_pipe" class="fixture" type="cylinder" size="0.015 0.0275" pos="0 0 0.0275" rgba="0.4 0.4 0.45 1"/>
+      <body name="valve" pos="0 0 0.065">
+        <joint name="valve_turn" type="hinge" axis="0 0 1" range="-3.0 3.0" damping="0.5" frictionloss="0.05"/>
+        <geom name="valve_hub"   type="cylinder" fromto="0 0 -0.006 0 0 0.006" size="0.014" mass="0.05" rgba="0.3 0.3 0.35 1" contype="1" conaffinity="1"/>
+        <geom name="valve_lever" type="box" size="0.035 0.008 0.006" pos="0.035 0 0" mass="0.05" rgba="0.7 0.2 0.2 1" contype="1" conaffinity="1"/>
+        <geom name="valve_grip"  type="cylinder" fromto="0.062 0 -0.02 0.062 0 0.02" size="0.007" mass="0.02" rgba="0.2 0.2 0.22 1" contype="1" conaffinity="1"/>
+      </body>
+    </body>
+
+    <!-- DOOR: a fixed post with a hinged panel that swings open about the vertical
+         edge; vertical handle bar at the far edge. -->
+    <body name="cabinet_door" pos="0.29 0.13 0.40">
+      <geom name="door_post" class="fixture" size="0.01 0.01 0.06" pos="0 -0.07 0.06" rgba="0.4 0.4 0.45 1"/>
+      <body name="door" pos="0 -0.07 0.06">
+        <joint name="door_hinge" type="hinge" axis="0 0 1" range="0 1.4" damping="0.2" frictionloss="0.02"/>
+        <geom name="door_panel"  type="box" size="0.006 0.06 0.05" pos="0 0.06 0" mass="0.08" rgba="0.55 0.45 0.3 1" contype="1" conaffinity="1"/>
+        <geom name="door_handle" type="cylinder" fromto="0 0.115 -0.02 0 0.115 0.02" size="0.007" mass="0.02" rgba="0.2 0.2 0.22 1" contype="1" conaffinity="1"/>
+      </body>
+    </body>
+  </worldbody>
+
+  <equality>
+    <weld name="grasp_right_drawer" body1="openarm_right_ee_base_link" body2="drawer" active="false" solref="0.02 1"/>
+    <weld name="grasp_left_drawer"  body1="openarm_left_ee_base_link"  body2="drawer" active="false" solref="0.02 1"/>
+    <weld name="grasp_right_valve"  body1="openarm_right_ee_base_link" body2="valve"  active="false" solref="0.02 1"/>
+    <weld name="grasp_left_valve"   body1="openarm_left_ee_base_link"  body2="valve"  active="false" solref="0.02 1"/>
+    <weld name="grasp_right_door"   body1="openarm_right_ee_base_link" body2="door"   active="false" solref="0.02 1"/>
+    <weld name="grasp_left_door"    body1="openarm_left_ee_base_link"  body2="door"   active="false" solref="0.02 1"/>
+  </equality>
+
+  <keyframe>
+    <!-- nq = left arm(0-8) + right arm(9-17) + drawer(18) + valve(19) + door(20) = 21.
+         Both arms start raised and clear of the fixtures (left = joint mirror of right). -->
+    <key name="ready"
+      qpos="0.720369 -2.27095 -0.290977 1.90389 -1.23759 -0.785149 -0.558776 0 0
+            -0.720369 2.27095 0.290977 1.90389 1.23759 0.785149 0.558776 0 0
+            0 0 0"/>
+  </keyframe>
+
+</mujoco>

--- a/v2/balance_scene.xml
+++ b/v2/balance_scene.xml
@@ -1,19 +1,24 @@
 <!--
 Copyright 2026 Enactic, Inc.
-Licensed under the Apache License, Version 2.0 (the "License").
 
-Ball-balance scene (Phase B1): the right arm holds a flat PLATE (welded to the
-gripper) on which a free PING-PONG BALL must be kept centred by tilting the plate.
-The arm's 7 DOF are used to (a) hold the plate at a fixed world position and
-(b) command small roll/pitch tilts about the plate centre; only those 2 axes of
-tilt actually do the balancing. The classical ball-on-plate stabilisation problem
-(textbook PID / LQR) lifted onto a 7-DOF manipulator -- distinct from the
-quasi-static manipulation skills the platform already has.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-The weld between plate and gripper is declared INACTIVE here and activated by
-BallBalancer at runtime once arm + plate have been teleported to the chosen
-"hold" pose -- exactly the same pattern PickPlaceController / ArticulatedController
-use for grasp welds, so the plate's resting pose vs gripper is captured exactly.
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<!--
+Ball balance: a flat plate (weldable to the right gripper) and a free ball.
+Tilting the plate rolls the ball -- the classic ball-on-plate stabilisation
+task on a 7-DOF arm. The plate weld starts inactive; a controller activates
+it at runtime after posing the arm.
 -->
 <mujoco model="openarm_v20_balance">
   <compiler meshdir="assets" angle="radian"/>
@@ -28,10 +33,10 @@ use for grasp welds, so the plate's resting pose vs gripper is captured exactly.
   </default>
 
   <statistic center="0.30 -0.05 0.60" extent="1.1" meansize="0.05"/>
-  <option timestep="0.002"/>
+  <option timestep="0.001"/>
 
   <visual>
-    <headlight diffuse="0.6 0.6 0.6" ambient="0.4 0.4 0.4" specular="0 0 0"/>
+    <headlight diffuse="0.6 0.6 0.6" ambient="0.3 0.3 0.3" specular="0 0 0"/>
     <rgba haze="0.15 0.25 0.35 1"/>
     <global azimuth="150" elevation="-20"/>
     <quality shadowsize="8192"/>
@@ -64,46 +69,35 @@ use for grasp welds, so the plate's resting pose vs gripper is captured exactly.
       <attach model="bimanual" prefix=""/>
     </frame>
 
-    <!-- Small backdrop table (the action happens ABOVE it; if the ball drops, the
-         table catches it for visual continuity instead of vanishing to the floor). -->
-    <body name="table" pos="0.30 -0.05 0.36">
-      <geom name="table_top" type="box" size="0.24 0.22 0.04" rgba="0.82 0.71 0.55 1"
+    <!-- Table: top at z=0.40, centered on the arm (y=0). Footprint matches the
+         cell workspace table in cell.xml (0.41 x 0.55 half-extents) so tabletop
+         layouts carry over; the cell mounts the arms on a lifter above the
+         table, so absolute heights differ. -->
+    <body name="table" pos="0.47 0.0 0.36">
+      <geom name="table_top" type="box" size="0.41 0.55 0.04" rgba="0.82 0.71 0.55 1"
             friction="1 0.005 0.0001" contype="1" conaffinity="1"/>
     </body>
 
-    <!-- PLATE: thin square plate. Free joint so the weld constraint can attach it
-         to the right gripper at runtime (same pattern as the existing grasp welds).
-         Visual half-size 7.5x7.5x0.5 cm = 15x15x1 cm; mass 50 g (light plastic).
-         Initial position is well above the workspace; BallBalancer teleports it
-         into place before activating the weld and before the user takes control. -->
-    <body name="plate" pos="0.30 -0.10 1.20">
+    <!-- Plate: 15x15x1 cm, 50 g. Free joint so the weld can attach it to the
+         right gripper at runtime. The riser rod is visual-only (no collision)
+         and reads as the stem the gripper holds. -->
+    <body name="plate" pos="0.30 0.0 0.405">
       <joint name="plate_free" type="free"/>
-      <inertial pos="0 0 0" mass="0.05" diaginertia="3.8e-4 3.8e-4 7.5e-4"/>
+      <inertial pos="0 0 0" mass="0.05" diaginertia="9.42e-5 9.42e-5 1.875e-4"/>
       <geom name="plate_top"   type="box" size="0.075 0.075 0.005" pos="0 0 0"
             rgba="0.35 0.55 0.85 1" contype="1" conaffinity="1"
             condim="6" friction="0.4 0.005 0.0002"
             solref="0.005 1" solimp="0.95 0.99 0.001"/>
-      <!-- Riser rod: a thin vertical cylinder attached to the plate, extending
-           DOWN to the gripper. Visual only (contype/conaffinity=0) so it can
-           pass through arm bodies without dynamics interaction. Reads as
-           "the gripper holds a table on a stem" -- necessary because the arm's
-           link4/5/6 occupy the palm-adjacent space in the ready pose and
-           there is no reachable joint config that gives a clear plate volume
-           above the palm. -->
-      <geom name="plate_riser" type="cylinder" size="0.008 0.060" pos="0 0 -0.065"
+      <geom name="plate_riser" type="cylinder" size="0.008 0.040" pos="0 0 -0.045"
             rgba="0.60 0.60 0.65 1" contype="0" conaffinity="0" group="2"/>
     </body>
 
-    <!-- BALL: real ping-pong specs (40 mm dia, 2.73 g). Restitution is governed by
-         the contact solver -- we deliberately want LOW bounce (the ball should
-         settle on the plate, not pogo). Critically-damped, stiff contact via
-         solref="0.005 1" solimp="0.95 0.99 0.001" combined with the plate's same
-         contact params gives a soft, near-inelastic settle. condim=6 lets the
-         contact resolve rolling friction (mu_roll ~ 1e-4) so the ball actually
-         rolls under tilt instead of jittering or sticking. -->
-    <body name="ball" pos="0.30 -0.10 1.30">
+    <!-- Ball: ping-pong specs (40 mm dia, 2.73 g). Stiff, near-inelastic contact
+         (low bounce); condim=6 resolves rolling friction so the ball rolls under
+         tilt instead of sticking. -->
+    <body name="ball" pos="0.30 0.0 0.430">
       <joint name="ball_free" type="free"/>
-      <inertial pos="0 0 0" mass="0.0027" diaginertia="4.32e-7 4.32e-7 4.32e-7"/>
+      <inertial pos="0 0 0" mass="0.0027" diaginertia="7.2e-7 7.2e-7 7.2e-7"/>
       <geom name="ball_geom" type="sphere" size="0.020"
             rgba="0.95 0.45 0.10 1" contype="1" conaffinity="1"
             condim="6" friction="0.35 0.005 0.0001"
@@ -112,21 +106,18 @@ use for grasp welds, so the plate's resting pose vs gripper is captured exactly.
   </worldbody>
 
   <equality>
-    <!-- Activated at runtime by BallBalancer (sets eq_data with the computed
-         relative pose, then eq_active=1). Until then, the plate is in free-fall. -->
+    <!-- Activated at runtime by a controller (set eq_data to the relative pose,
+         then eq_active=1). Until then, the plate is a free body. -->
+    <!-- Stiffer than the grasp welds in the other scenes: the plate must not
+         lag the wrist or the ball reads phantom accelerations. -->
     <weld name="plate_to_right_ee" body1="openarm_right_ee_base_link" body2="plate"
           active="false" solref="0.005 1"/>
   </equality>
 
   <contact>
-    <!-- The plate is pinned to the right gripper at a fixed offset above the
-         arm; its geometry visually needs to be well above the wrist bodies for
-         the "arm-below-plate-on-top" reading, but the arm's link4/5/6 occupy
-         those heights in the ready pose. Excluding the plate/ball from every
-         right-arm body up to link4 makes the internal-to-welded-system
-         penetrations dynamically inert while the render-only riser rod bridges
-         the visual gap. The finger self-collisions are the natural ones you
-         see in every scene and are left alone. -->
+    <!-- When the plate is welded above the gripper, its volume overlaps the
+         wrist bodies; excluding those pairs makes the internal penetrations of
+         the welded assembly dynamically inert. -->
     <exclude body1="plate" body2="openarm_right_ee_base_link"/>
     <exclude body1="plate" body2="openarm_right_ee_inner_finger"/>
     <exclude body1="plate" body2="openarm_right_ee_outer_finger"/>
@@ -143,14 +134,16 @@ use for grasp welds, so the plate's resting pose vs gripper is captured exactly.
 
   <keyframe>
     <!-- nq = left arm(0-8) + right arm(9-17) + plate_free(18-24) + ball_free(25-31) = 32.
-         Arms at the raised "ready" pose (shared with the other scenes). Plate +
-         ball start in the air above the workspace; BallBalancer immediately
-         teleports them to the correct hold position. -->
-    <key name="ready"
-      qpos="0.720369 -2.27095 -0.290977 1.90389 -1.23759 -0.785149 -0.558776 0 0
-            -0.720369 2.27095 0.290977 1.90389 1.23759 0.785149 0.558776 0 0
-            0.32 -0.12 0.58 1 0 0 0
-            0.32 -0.12 0.625 1 0 0 0"/>
+         Arms at the shared "home" pose (same as pedestal.xml, with ctrl set so
+         the position actuators hold it); plate rests on the table, ball on the
+         plate. -->
+    <key name="home"
+      qpos="0.0 0.0 0.0 1.570796 0.0 0.0 0.0 0.0 0.0
+            0.0 0.0 0.0 1.570796 0.0 0.0 0.0 0.0 0.0
+            0.30 0.0 0.405 1 0 0 0
+            0.30 0.0 0.430 1 0 0 0"
+      ctrl="0 0 0 1.570796 0 0 0 0
+            0 0 0 1.570796 0 0 0 0"/>
   </keyframe>
 
 </mujoco>

--- a/v2/balance_scene.xml
+++ b/v2/balance_scene.xml
@@ -1,0 +1,156 @@
+<!--
+Copyright 2026 Enactic, Inc.
+Licensed under the Apache License, Version 2.0 (the "License").
+
+Ball-balance scene (Phase B1): the right arm holds a flat PLATE (welded to the
+gripper) on which a free PING-PONG BALL must be kept centred by tilting the plate.
+The arm's 7 DOF are used to (a) hold the plate at a fixed world position and
+(b) command small roll/pitch tilts about the plate centre; only those 2 axes of
+tilt actually do the balancing. The classical ball-on-plate stabilisation problem
+(textbook PID / LQR) lifted onto a 7-DOF manipulator -- distinct from the
+quasi-static manipulation skills the platform already has.
+
+The weld between plate and gripper is declared INACTIVE here and activated by
+BallBalancer at runtime once arm + plate have been teleported to the chosen
+"hold" pose -- exactly the same pattern PickPlaceController / ArticulatedController
+use for grasp welds, so the plate's resting pose vs gripper is captured exactly.
+-->
+<mujoco model="openarm_v20_balance">
+  <compiler meshdir="assets" angle="radian"/>
+
+  <default>
+    <default class="visual">
+      <geom contype="0" conaffinity="0" group="2"/>
+    </default>
+    <default class="collision">
+      <geom condim="3" conaffinity="1" priority="1" group="3" solref="0.005 1" friction="1 0.01 0.01"/>
+    </default>
+  </default>
+
+  <statistic center="0.30 -0.05 0.60" extent="1.1" meansize="0.05"/>
+  <option timestep="0.002"/>
+
+  <visual>
+    <headlight diffuse="0.6 0.6 0.6" ambient="0.4 0.4 0.4" specular="0 0 0"/>
+    <rgba haze="0.15 0.25 0.35 1"/>
+    <global azimuth="150" elevation="-20"/>
+    <quality shadowsize="8192"/>
+  </visual>
+
+  <asset>
+    <texture type="skybox" builtin="gradient" rgb1="0.55 0.55 0.58" rgb2="0.2 0.2 0.2" width="512" height="3072"/>
+    <texture type="2d" name="groundplane" builtin="checker" mark="edge" rgb1="0.38 0.38 0.4" rgb2="0.3 0.3 0.32"
+      markrgb="0.6 0.6 0.6" width="300" height="300"/>
+    <material name="groundplane" texture="groundplane" texuniform="true" texrepeat="5 5" reflectance="0.2"/>
+
+    <material name="openarm_body_link0_material" rgba="0.247 0.247 0.247 1.0" reflectance="0.05" shininess="0.5"/>
+    <mesh name="body_link0"      content_type="model/stl" file="visual/body/body_link0.stl"     scale="0.001 0.001 0.001"/>
+    <mesh name="body_link0_symp" content_type="model/stl" file="collision/body_link0_symp.stl" scale="0.001 0.001 0.001"/>
+
+    <model name="bimanual" file="openarm_bimanual.xml"/>
+  </asset>
+
+  <worldbody>
+    <light pos="0 0 2" dir="0 0 -1" directional="true"/>
+    <geom name="floor" size="0 0 0.05" type="plane" material="groundplane"/>
+
+    <camera name="balancecam" pos="0.75 -0.40 0.95" xyaxes="0.5 0.866 0 -0.35 0.20 0.92" fovy="50"/>
+    <camera name="topcam"     pos="0.30 -0.05 1.30" xyaxes="1 0 0 0 1 0" fovy="55"/>
+
+    <geom name="openarm_body_link0_visual"    type="mesh" mesh="body_link0"      class="visual"    material="openarm_body_link0_material"/>
+    <geom name="openarm_body_link0_collision" type="mesh" mesh="body_link0_symp" class="collision"/>
+
+    <frame pos="0 0 0.698">
+      <attach model="bimanual" prefix=""/>
+    </frame>
+
+    <!-- Small backdrop table (the action happens ABOVE it; if the ball drops, the
+         table catches it for visual continuity instead of vanishing to the floor). -->
+    <body name="table" pos="0.30 -0.05 0.36">
+      <geom name="table_top" type="box" size="0.24 0.22 0.04" rgba="0.82 0.71 0.55 1"
+            friction="1 0.005 0.0001" contype="1" conaffinity="1"/>
+    </body>
+
+    <!-- PLATE: thin square plate. Free joint so the weld constraint can attach it
+         to the right gripper at runtime (same pattern as the existing grasp welds).
+         Visual half-size 7.5x7.5x0.5 cm = 15x15x1 cm; mass 50 g (light plastic).
+         Initial position is well above the workspace; BallBalancer teleports it
+         into place before activating the weld and before the user takes control. -->
+    <body name="plate" pos="0.30 -0.10 1.20">
+      <joint name="plate_free" type="free"/>
+      <inertial pos="0 0 0" mass="0.05" diaginertia="3.8e-4 3.8e-4 7.5e-4"/>
+      <geom name="plate_top"   type="box" size="0.075 0.075 0.005" pos="0 0 0"
+            rgba="0.35 0.55 0.85 1" contype="1" conaffinity="1"
+            condim="6" friction="0.4 0.005 0.0002"
+            solref="0.005 1" solimp="0.95 0.99 0.001"/>
+      <!-- Riser rod: a thin vertical cylinder attached to the plate, extending
+           DOWN to the gripper. Visual only (contype/conaffinity=0) so it can
+           pass through arm bodies without dynamics interaction. Reads as
+           "the gripper holds a table on a stem" -- necessary because the arm's
+           link4/5/6 occupy the palm-adjacent space in the ready pose and
+           there is no reachable joint config that gives a clear plate volume
+           above the palm. -->
+      <geom name="plate_riser" type="cylinder" size="0.008 0.060" pos="0 0 -0.065"
+            rgba="0.60 0.60 0.65 1" contype="0" conaffinity="0" group="2"/>
+    </body>
+
+    <!-- BALL: real ping-pong specs (40 mm dia, 2.73 g). Restitution is governed by
+         the contact solver -- we deliberately want LOW bounce (the ball should
+         settle on the plate, not pogo). Critically-damped, stiff contact via
+         solref="0.005 1" solimp="0.95 0.99 0.001" combined with the plate's same
+         contact params gives a soft, near-inelastic settle. condim=6 lets the
+         contact resolve rolling friction (mu_roll ~ 1e-4) so the ball actually
+         rolls under tilt instead of jittering or sticking. -->
+    <body name="ball" pos="0.30 -0.10 1.30">
+      <joint name="ball_free" type="free"/>
+      <inertial pos="0 0 0" mass="0.0027" diaginertia="4.32e-7 4.32e-7 4.32e-7"/>
+      <geom name="ball_geom" type="sphere" size="0.020"
+            rgba="0.95 0.45 0.10 1" contype="1" conaffinity="1"
+            condim="6" friction="0.35 0.005 0.0001"
+            solref="0.005 1" solimp="0.95 0.99 0.001"/>
+    </body>
+  </worldbody>
+
+  <equality>
+    <!-- Activated at runtime by BallBalancer (sets eq_data with the computed
+         relative pose, then eq_active=1). Until then, the plate is in free-fall. -->
+    <weld name="plate_to_right_ee" body1="openarm_right_ee_base_link" body2="plate"
+          active="false" solref="0.005 1"/>
+  </equality>
+
+  <contact>
+    <!-- The plate is pinned to the right gripper at a fixed offset above the
+         arm; its geometry visually needs to be well above the wrist bodies for
+         the "arm-below-plate-on-top" reading, but the arm's link4/5/6 occupy
+         those heights in the ready pose. Excluding the plate/ball from every
+         right-arm body up to link4 makes the internal-to-welded-system
+         penetrations dynamically inert while the render-only riser rod bridges
+         the visual gap. The finger self-collisions are the natural ones you
+         see in every scene and are left alone. -->
+    <exclude body1="plate" body2="openarm_right_ee_base_link"/>
+    <exclude body1="plate" body2="openarm_right_ee_inner_finger"/>
+    <exclude body1="plate" body2="openarm_right_ee_outer_finger"/>
+    <exclude body1="plate" body2="openarm_right_link4"/>
+    <exclude body1="plate" body2="openarm_right_link5"/>
+    <exclude body1="plate" body2="openarm_right_link6"/>
+    <exclude body1="ball"  body2="openarm_right_ee_base_link"/>
+    <exclude body1="ball"  body2="openarm_right_ee_inner_finger"/>
+    <exclude body1="ball"  body2="openarm_right_ee_outer_finger"/>
+    <exclude body1="ball"  body2="openarm_right_link4"/>
+    <exclude body1="ball"  body2="openarm_right_link5"/>
+    <exclude body1="ball"  body2="openarm_right_link6"/>
+  </contact>
+
+  <keyframe>
+    <!-- nq = left arm(0-8) + right arm(9-17) + plate_free(18-24) + ball_free(25-31) = 32.
+         Arms at the raised "ready" pose (shared with the other scenes). Plate +
+         ball start in the air above the workspace; BallBalancer immediately
+         teleports them to the correct hold position. -->
+    <key name="ready"
+      qpos="0.720369 -2.27095 -0.290977 1.90389 -1.23759 -0.785149 -0.558776 0 0
+            -0.720369 2.27095 0.290977 1.90389 1.23759 0.785149 0.558776 0 0
+            0.32 -0.12 0.58 1 0 0 0
+            0.32 -0.12 0.625 1 0 0 0"/>
+  </keyframe>
+
+</mujoco>

--- a/v2/peg_socket_scene.xml
+++ b/v2/peg_socket_scene.xml
@@ -1,12 +1,24 @@
 <!--
 Copyright 2026 Enactic, Inc.
-Licensed under the Apache License, Version 2.0 (the "License").
-Peg-in-hole scene (Phase I, M6): a cylindrical peg standing on a table and a
-CIRCULAR socket (an octagonal ring of walls) a short distance away. The robot
-grasps the peg and inserts it into the socket -- a precise vertical descent
-threading the peg through the round opening (a few mm radial clearance). A
-cylinder is rotationally symmetric, so no yaw alignment is needed (the
-free-yaw case in the round/square/cuboid insertion family). Classical control.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<!--
+Peg-in-hole insertion: a cylindrical peg standing on a table and a circular
+socket (an octagonal ring of walls) nearby. The peg threads down through the
+socket opening with a few mm of radial clearance; being rotationally symmetric,
+it needs no yaw alignment.
 -->
 
 <mujoco model="openarm_v20_peg_socket">
@@ -22,10 +34,10 @@ free-yaw case in the round/square/cuboid insertion family). Classical control.
   </default>
 
   <statistic center="0 0 0.6" extent="1.1" meansize="0.05"/>
-  <option timestep="0.002" />
+  <option timestep="0.001" />
 
   <visual>
-    <headlight diffuse="0.6 0.6 0.6" ambient="0.4 0.4 0.4" specular="0 0 0"/>
+    <headlight diffuse="0.6 0.6 0.6" ambient="0.3 0.3 0.3" specular="0 0 0"/>
     <rgba haze="0.15 0.25 0.35 1"/>
     <global azimuth="150" elevation="-20"/>
     <quality shadowsize="8192"/>
@@ -58,15 +70,19 @@ free-yaw case in the round/square/cuboid insertion family). Classical control.
       <attach model="bimanual" prefix=""/>
     </frame>
 
-    <!-- Table: top at z=0.40. -->
-    <body name="table" pos="0.27 -0.23 0.36">
-      <geom name="table_top" type="box" size="0.22 0.24 0.04" rgba="0.82 0.71 0.55 1"
+    <!-- Table: top at z=0.40, centered on the arm (y=0). Footprint matches the
+         cell workspace table in cell.xml (0.41 x 0.55 half-extents) so tabletop
+         layouts carry over; the cell mounts the arms on a lifter above the
+         table, so absolute heights differ. -->
+    <body name="table" pos="0.47 0.0 0.36">
+      <geom name="table_top" type="box" size="0.41 0.55 0.04" rgba="0.82 0.71 0.55 1"
             friction="1 0.005 0.0001" contype="1" conaffinity="1" />
     </body>
 
-    <!-- The peg: a cylinder (radius 0.014, half-length 0.045) standing on the table. -->
-    <body name="peg" pos="0.19 -0.15 0.445">
-      <freejoint />
+    <!-- The peg: a cylinder (radius 0.014, half-length 0.045) standing on the
+         table, clear of the grippers' home-pose footprint. -->
+    <body name="peg" pos="0.36 -0.10 0.445">
+      <joint name="peg_free" type="free"/>
       <geom name="peg_geom" type="cylinder" size="0.014 0.045" rgba="0.15 0.3 0.85 1"
             mass="0.05" friction="2.0 0.1 0.01" contype="1" conaffinity="1" />
     </body>
@@ -75,7 +91,7 @@ free-yaw case in the round/square/cuboid insertion family). Classical control.
          an octagon (inner apothem 0.020 m, walls 0.05 m tall). The round peg
          (radius 0.014 m) threads down through the centre and rests on the table;
          a cylinder needs no yaw alignment, so any approach orientation works. -->
-    <body name="socket" pos="0.36 -0.30 0.40">
+    <body name="socket" pos="0.36 -0.26 0.40">
       <geom name="socket_0" type="box" size="0.012 0.005 0.025" pos="0.025 0 0.025" euler="0 0 1.5708" rgba="0.5 0.5 0.55 1" contype="1" conaffinity="1"/>
       <geom name="socket_1" type="box" size="0.012 0.005 0.025" pos="0.01768 0.01768 0.025" euler="0 0 2.3562" rgba="0.5 0.5 0.55 1" contype="1" conaffinity="1"/>
       <geom name="socket_2" type="box" size="0.012 0.005 0.025" pos="0 0.025 0.025" euler="0 0 3.1416" rgba="0.5 0.5 0.55 1" contype="1" conaffinity="1"/>
@@ -93,11 +109,15 @@ free-yaw case in the round/square/cuboid insertion family). Classical control.
   </equality>
 
   <keyframe>
-    <!-- nq = left arm(0-8) + right arm(9-17) + peg(18-24) = 25. -->
-    <key name="ready"
-      qpos="0 0 0 0 0 0 0 0 0
-            -0.720369 2.27095 0.290977 1.90389 1.23759 0.785149 0.558776 0 0
-            0.19 -0.15 0.445 1 0 0 0" />
+    <!-- nq = left arm(0-8) + right arm(9-17) + peg(18-24) = 25.
+         Arms at the shared "home" pose (same as pedestal.xml, with ctrl set so
+         the position actuators hold it); peg upright on the table. -->
+    <key name="home"
+      qpos="0.0 0.0 0.0 1.570796 0.0 0.0 0.0 0.0 0.0
+            0.0 0.0 0.0 1.570796 0.0 0.0 0.0 0.0 0.0
+            0.36 -0.10 0.445 1 0 0 0"
+      ctrl="0 0 0 1.570796 0 0 0 0
+            0 0 0 1.570796 0 0 0 0"/>
   </keyframe>
 
 </mujoco>

--- a/v2/peg_socket_scene.xml
+++ b/v2/peg_socket_scene.xml
@@ -1,0 +1,103 @@
+<!--
+Copyright 2026 Enactic, Inc.
+Licensed under the Apache License, Version 2.0 (the "License").
+Peg-in-hole scene (Phase I, M6): a cylindrical peg standing on a table and a
+CIRCULAR socket (an octagonal ring of walls) a short distance away. The robot
+grasps the peg and inserts it into the socket -- a precise vertical descent
+threading the peg through the round opening (a few mm radial clearance). A
+cylinder is rotationally symmetric, so no yaw alignment is needed (the
+free-yaw case in the round/square/cuboid insertion family). Classical control.
+-->
+
+<mujoco model="openarm_v20_peg_socket">
+  <compiler meshdir="assets" angle="radian"/>
+
+  <default>
+    <default class="visual">
+      <geom contype="0" conaffinity="0" group="2" />
+    </default>
+    <default class="collision">
+      <geom condim="3" conaffinity="1" priority="1" group="3" solref="0.005 1" friction="1 0.01 0.01" />
+    </default>
+  </default>
+
+  <statistic center="0 0 0.6" extent="1.1" meansize="0.05"/>
+  <option timestep="0.002" />
+
+  <visual>
+    <headlight diffuse="0.6 0.6 0.6" ambient="0.4 0.4 0.4" specular="0 0 0"/>
+    <rgba haze="0.15 0.25 0.35 1"/>
+    <global azimuth="150" elevation="-20"/>
+    <quality shadowsize="8192"/>
+  </visual>
+
+  <asset>
+    <texture type="skybox" builtin="gradient" rgb1="0.55 0.55 0.58" rgb2="0.2 0.2 0.2" width="512" height="3072"/>
+    <texture type="2d" name="groundplane" builtin="checker" mark="edge" rgb1="0.38 0.38 0.4" rgb2="0.3 0.3 0.32"
+      markrgb="0.6 0.6 0.6" width="300" height="300"/>
+    <material name="groundplane" texture="groundplane" texuniform="true" texrepeat="5 5" reflectance="0.2"/>
+
+    <material name="openarm_body_link0_material" rgba="0.247 0.247 0.247 1.0" reflectance="0.05" shininess="0.5"/>
+    <mesh name="body_link0"      content_type="model/stl" file="visual/body/body_link0.stl"        scale="0.001 0.001 0.001" />
+    <mesh name="body_link0_symp" content_type="model/stl" file="collision/body_link0_symp.stl"    scale="0.001 0.001 0.001" />
+
+    <model name="bimanual" file="openarm_bimanual.xml"/>
+  </asset>
+
+  <worldbody>
+    <light pos="0 0 2" dir="0 0 -1" directional="true"/>
+    <geom name="floor" size="0 0 0.05" type="plane" material="groundplane"/>
+
+    <camera name="tablecam" pos="0.28 -0.22 1.15" xyaxes="1 0 0 0 1 0" fovy="55"/>
+    <camera name="frontcam" pos="0.95 -0.22 0.85" xyaxes="0 -1 0 0.3 0 1" fovy="50"/>
+
+    <geom name="openarm_body_link0_visual"    type="mesh" mesh="body_link0"      class="visual"    material="openarm_body_link0_material" />
+    <geom name="openarm_body_link0_collision" type="mesh" mesh="body_link0_symp" class="collision" />
+
+    <frame pos="0 0 0.698">
+      <attach model="bimanual" prefix=""/>
+    </frame>
+
+    <!-- Table: top at z=0.40. -->
+    <body name="table" pos="0.27 -0.23 0.36">
+      <geom name="table_top" type="box" size="0.22 0.24 0.04" rgba="0.82 0.71 0.55 1"
+            friction="1 0.005 0.0001" contype="1" conaffinity="1" />
+    </body>
+
+    <!-- The peg: a cylinder (radius 0.014, half-length 0.045) standing on the table. -->
+    <body name="peg" pos="0.19 -0.15 0.445">
+      <freejoint />
+      <geom name="peg_geom" type="cylinder" size="0.014 0.045" rgba="0.15 0.3 0.85 1"
+            mass="0.05" friction="2.0 0.1 0.01" contype="1" conaffinity="1" />
+    </body>
+
+    <!-- The socket: a CIRCULAR pocket approximated by eight wall segments forming
+         an octagon (inner apothem 0.020 m, walls 0.05 m tall). The round peg
+         (radius 0.014 m) threads down through the centre and rests on the table;
+         a cylinder needs no yaw alignment, so any approach orientation works. -->
+    <body name="socket" pos="0.36 -0.30 0.40">
+      <geom name="socket_0" type="box" size="0.012 0.005 0.025" pos="0.025 0 0.025" euler="0 0 1.5708" rgba="0.5 0.5 0.55 1" contype="1" conaffinity="1"/>
+      <geom name="socket_1" type="box" size="0.012 0.005 0.025" pos="0.01768 0.01768 0.025" euler="0 0 2.3562" rgba="0.5 0.5 0.55 1" contype="1" conaffinity="1"/>
+      <geom name="socket_2" type="box" size="0.012 0.005 0.025" pos="0 0.025 0.025" euler="0 0 3.1416" rgba="0.5 0.5 0.55 1" contype="1" conaffinity="1"/>
+      <geom name="socket_3" type="box" size="0.012 0.005 0.025" pos="-0.01768 0.01768 0.025" euler="0 0 3.9270" rgba="0.5 0.5 0.55 1" contype="1" conaffinity="1"/>
+      <geom name="socket_4" type="box" size="0.012 0.005 0.025" pos="-0.025 0 0.025" euler="0 0 4.7124" rgba="0.5 0.5 0.55 1" contype="1" conaffinity="1"/>
+      <geom name="socket_5" type="box" size="0.012 0.005 0.025" pos="-0.01768 -0.01768 0.025" euler="0 0 5.4978" rgba="0.5 0.5 0.55 1" contype="1" conaffinity="1"/>
+      <geom name="socket_6" type="box" size="0.012 0.005 0.025" pos="0 -0.025 0.025" euler="0 0 0" rgba="0.5 0.5 0.55 1" contype="1" conaffinity="1"/>
+      <geom name="socket_7" type="box" size="0.012 0.005 0.025" pos="0.01768 -0.01768 0.025" euler="0 0 0.7854" rgba="0.5 0.5 0.55 1" contype="1" conaffinity="1"/>
+      <site name="socket_center" pos="0 0 0.05" size="0.004" rgba="0.9 0.2 0.2 0.6"/>
+    </body>
+  </worldbody>
+
+  <equality>
+    <weld name="grasp_right_peg" body1="openarm_right_ee_base_link" body2="peg" active="false" solref="0.02 1"/>
+  </equality>
+
+  <keyframe>
+    <!-- nq = left arm(0-8) + right arm(9-17) + peg(18-24) = 25. -->
+    <key name="ready"
+      qpos="0 0 0 0 0 0 0 0 0
+            -0.720369 2.27095 0.290977 1.90389 1.23759 0.785149 0.558776 0 0
+            0.19 -0.15 0.445 1 0 0 0" />
+  </keyframe>
+
+</mujoco>

--- a/v2/valve_scene.xml
+++ b/v2/valve_scene.xml
@@ -1,0 +1,113 @@
+<!--
+Copyright 2026 Enactic, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<!--
+Valve: a fixed pipe with a turnable lever (revolute joint) on a table, with a
+graspable knob at the lever tip and inactive grasp welds for either arm.
+-->
+<mujoco model="openarm_v20_valve">
+  <compiler meshdir="assets" angle="radian"/>
+
+  <default>
+    <default class="visual">
+      <geom contype="0" conaffinity="0" group="2"/>
+    </default>
+    <default class="collision">
+      <geom condim="3" conaffinity="1" priority="1" group="3" solref="0.005 1" friction="1 0.01 0.01"/>
+    </default>
+    <default class="fixture">
+      <geom type="box" contype="1" conaffinity="1" friction="1 0.01 0.01" rgba="0.55 0.45 0.32 1"/>
+    </default>
+  </default>
+
+  <statistic center="0.30 0 0.55" extent="1.2" meansize="0.05"/>
+  <option timestep="0.001"/>
+
+  <visual>
+    <headlight diffuse="0.6 0.6 0.6" ambient="0.3 0.3 0.3" specular="0 0 0"/>
+    <rgba haze="0.15 0.25 0.35 1"/>
+    <global azimuth="150" elevation="-20"/>
+    <quality shadowsize="8192"/>
+  </visual>
+
+  <asset>
+    <texture type="skybox" builtin="gradient" rgb1="0.55 0.55 0.58" rgb2="0.2 0.2 0.2" width="512" height="3072"/>
+    <texture type="2d" name="groundplane" builtin="checker" mark="edge" rgb1="0.38 0.38 0.4" rgb2="0.3 0.3 0.32"
+      markrgb="0.6 0.6 0.6" width="300" height="300"/>
+    <material name="groundplane" texture="groundplane" texuniform="true" texrepeat="5 5" reflectance="0.2"/>
+
+    <material name="openarm_body_link0_material" rgba="0.247 0.247 0.247 1.0" reflectance="0.05" shininess="0.5"/>
+    <mesh name="body_link0"      content_type="model/stl" file="visual/body/body_link0.stl"     scale="0.001 0.001 0.001"/>
+    <mesh name="body_link0_symp" content_type="model/stl" file="collision/body_link0_symp.stl" scale="0.001 0.001 0.001"/>
+
+    <model name="bimanual" file="openarm_bimanual.xml"/>
+  </asset>
+
+  <worldbody>
+    <light pos="0 0 2" dir="0 0 -1" directional="true"/>
+    <geom name="floor" size="0 0 0.05" type="plane" material="groundplane"/>
+
+    <camera name="tablecam" pos="0.30 0.0 1.30" xyaxes="1 0 0 0 1 0" fovy="60"/>
+    <camera name="frontcam" pos="1.05 0.0 0.90" xyaxes="0 -1 0 0.3 0 1" fovy="55"/>
+
+    <geom name="openarm_body_link0_visual"    type="mesh" mesh="body_link0"      class="visual"    material="openarm_body_link0_material"/>
+    <geom name="openarm_body_link0_collision" type="mesh" mesh="body_link0_symp" class="collision"/>
+
+    <frame pos="0 0 0.698">
+      <attach model="bimanual" prefix=""/>
+    </frame>
+
+    <!-- Table: top at z=0.40, centered on the arm (y=0). Footprint matches the
+         cell workspace table in cell.xml (0.41 x 0.55 half-extents) so tabletop
+         layouts carry over; the cell mounts the arms on a lifter above the
+         table, so absolute heights differ. -->
+    <body name="table" pos="0.47 0.0 0.36">
+      <geom name="table_top" type="box" size="0.41 0.55 0.04" rgba="0.82 0.71 0.55 1"
+            friction="1 0.005 0.0001" contype="1" conaffinity="1"/>
+    </body>
+
+    <!-- VALVE: a fixed pipe with a lever that turns about the vertical axis; grasp
+         the knob at the lever tip and sweep it in an arc. -->
+    <body name="valve_base" pos="0.14 0.0 0.40">
+      <geom name="valve_pipe" class="fixture" type="cylinder" size="0.015 0.0275" pos="0 0 0.0275" rgba="0.4 0.4 0.45 1"/>
+      <body name="valve" pos="0 0 0.065">
+        <joint name="valve_turn" type="hinge" axis="0 0 1" range="-3.0 3.0" damping="0.5" frictionloss="0.05"/>
+        <geom name="valve_hub"   type="cylinder" fromto="0 0 -0.006 0 0 0.006" size="0.014" mass="0.05" rgba="0.3 0.3 0.35 1" contype="1" conaffinity="1"/>
+        <geom name="valve_lever" type="box" size="0.035 0.008 0.006" pos="0.035 0 0" mass="0.05" rgba="0.7 0.2 0.2 1" contype="1" conaffinity="1"/>
+        <geom name="valve_grip"  type="cylinder" fromto="0.062 0 -0.02 0.062 0 0.02" size="0.007" mass="0.02" rgba="0.2 0.2 0.22 1" contype="1" conaffinity="1"/>
+      </body>
+    </body>
+
+  </worldbody>
+
+  <equality>
+    <weld name="grasp_right_valve" body1="openarm_right_ee_base_link" body2="valve" active="false" solref="0.02 1"/>
+    <weld name="grasp_left_valve"  body1="openarm_left_ee_base_link"  body2="valve" active="false" solref="0.02 1"/>
+  </equality>
+
+  <keyframe>
+    <!-- nq = left arm(0-8) + right arm(9-17) + valve(18) = 19.
+         Arms at the shared "home" pose (same as pedestal.xml, with ctrl set so
+         the position actuators hold it); valve closed. -->
+    <key name="home"
+      qpos="0.0 0.0 0.0 1.570796 0.0 0.0 0.0 0.0 0.0
+            0.0 0.0 0.0 1.570796 0.0 0.0 0.0 0.0 0.0
+            0"
+      ctrl="0 0 0 1.570796 0 0 0 0
+            0 0 0 1.570796 0 0 0 0"/>
+  </keyframe>
+
+</mujoco>

--- a/v2/valve_scene.xml
+++ b/v2/valve_scene.xml
@@ -81,7 +81,7 @@ graspable knob at the lever tip and inactive grasp welds for either arm.
 
     <!-- VALVE: a fixed pipe with a lever that turns about the vertical axis; grasp
          the knob at the lever tip and sweep it in an arc. -->
-    <body name="valve_base" pos="0.14 0.0 0.40">
+    <body name="valve_base" pos="0.25 0.0 0.40">
       <geom name="valve_pipe" class="fixture" type="cylinder" size="0.015 0.0275" pos="0 0 0.0275" rgba="0.4 0.4 0.45 1"/>
       <body name="valve" pos="0 0 0.065">
         <joint name="valve_turn" type="hinge" axis="0 0 1" range="-3.0 3.0" damping="0.5" frictionloss="0.05"/>


### PR DESCRIPTION
Context: https://github.com/enactic/openarm_mujoco/discussions/39

Three self-contained task scenes built around `openarm_bimanual.xml`, following the same pedestal + attach pattern as `pedestal.xml`:

- **`peg_socket_scene.xml`** - peg-in-hole insertion: a graspable peg and a table-mounted socket, with a `ready` keyframe.
- **`articulated_scene.xml`** - a drawer (prismatic), a cabinet door (revolute) and a valve (hinge) at reachable poses, with joint limits and damping tuned for stable interaction.
- **`balance_scene.xml`** - a plate that can be welded to the right gripper plus a free ball, for the classic ball-on-plate stabilisation problem on a 7-DOF arm. The weld starts inactive so a controller can activate it after posing the arm.

Each scene loads standalone (`python -m mujoco.viewer --mjcf=v2/<scene>.xml`), applies its `ready` keyframe cleanly, and simulates 1000+ steps against the current model without contact instability.

They don't modify the model file. Since the material names in `openarm_bimanual.xml` have changed over time, each scene defines its own pedestal material the way `pedestal.xml` does, so they stay decoupled from the model's internal naming.

These are extracted from a control platform I maintain on top of this model (https://github.com/Manas-arumalla/openarm-control), where they're exercised by a CI test suite. Happy to adjust naming/placement or add the remaining scenes (cloth, contact, catching, throwing) if there's interest.