### PR TITLE
Swap left and right head camera to align with observer

### DIFF
--- a/v2/cell.xml
+++ b/v2/cell.xml
@@ -84,8 +84,8 @@ limitations under the License.
 
     <camera name="camera_ceiling" pos="0.245 0 1.8" xyaxes="0 -1 0 1 0 0"    fovy="66" resolution="960 600"/>
     <!-- need to adjust x after lifter link is adjusted -->
-    <camera name="camera_head_left"    pos="0.223 -0.0315 1.45"  xyaxes="0 -1 0 0.882948 0 0.469472" fovy="52" resolution="1280 720"/>
-    <camera name="camera_head_right"    pos="0.223 0.0315 1.45"  xyaxes="0 -1 0 0.882948 0 0.469472" fovy="52" resolution="1280 720"/>
+    <camera name="camera_head_left"    pos="0.223 0.0315 1.45"  xyaxes="0 -1 0 0.882948 0 0.469472" fovy="52" resolution="1280 720"/>
+    <camera name="camera_head_right"    pos="0.223 -0.0315 1.45"  xyaxes="0 -1 0 0.882948 0 0.469472" fovy="52" resolution="1280 720"/>
 
     <!-- lifter body: arms attach here and slide vertically -->
     <body name="openarm_lifter_link" pos="0.185 0 1.34">


### PR DESCRIPTION
Currently the right/left camera in mujoco has the reversed order as observer/wrist.
<img width="2039" height="1433" alt="image" src="https://github.com/user-attachments/assets/47745265-0962-45ce-9dfa-6faf9efdff44" />

This PR swaps the left and right camera to align with the convention (facing front).