### PR TITLE
Add OpenArm MuJoCo Web

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -12,19 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-repos:
-  - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.14.11
-    hooks:
-      - id: ruff-check
-        args:
-          - --fix
-      - id: ruff-format
-  - repo: https://github.com/biomejs/pre-commit
-    rev: v2.5.3
-    hooks:
-      - id: biome-check
-  - repo: https://github.com/scop/pre-commit-shfmt
-    rev: v3.12.0-2
-    hooks:
-      - id: shfmt
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "ci: "
+    open-pull-requests-limit: 10
+  - package-ecosystem: "npm"
+    directory: "/web"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "web: "
+    open-pull-requests-limit: 10

--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -1,0 +1,59 @@
+# Copyright 2026 Enactic, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Pages
+on:
+  push:
+    branches-ignore:
+      - 'copilot/**'
+      - 'dependabot/**'
+    tags:
+      - '**'
+  pull_request:
+concurrency:
+  group: ${{ github.ref }}-${{ github.workflow }}
+  cancel-in-progress: true
+permissions:
+  contents: read
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Collect the published files
+        # OpenArm MuJoCo Web only needs the page (index.html), its modules
+        # (web/*.js; three and @mujoco/mujoco come from the jsDelivr CDN),
+        # web/package-lock.json (the page builds its import map from it) and
+        # the v2 model files the page fetches.
+        run: |
+          mkdir -p _site/web
+          cp index.html _site/
+          cp web/*.js web/package-lock.json _site/web/
+          cp -r v2 _site/
+      - uses: actions/upload-pages-artifact@v4
+  deploy:
+    name: Deploy
+    if: github.event_name == 'push'
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/preview-comment.yaml
+++ b/.github/workflows/preview-comment.yaml
@@ -1,0 +1,50 @@
+# Copyright 2026 Enactic, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Preview comment
+on:
+  pull_request_target:
+    types:
+      - opened
+permissions:
+  contents: read
+  pull-requests: write
+jobs:
+  post:
+    name: Post
+    if:
+      github.event.pull_request.base.repo.full_name == 'enactic/openarm_mujoco'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      # We must not checkout fork repository and execute any scripts
+      # in fork repository. It has security risks.
+      - name: Comment
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_REPOSITORY: ${{ github.event.pull_request.base.repo.full_name }}
+          FORK_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name }}
+          PR_NUMBER: ${{ github.event.number }}
+        run: |
+          configure_url="https://github.com/enactic/openarm_mujoco/blob/main/README.md#pull-request-and-preview"
+          fork_owner=${FORK_REPOSITORY%/*}
+          fork_repository=${FORK_REPOSITORY#*/}
+          cat <<COMMENT > body.md
+          Preview: https://${fork_owner}.github.io/${fork_repository}
+
+          See ${configure_url} how to configure preview on fork.
+          COMMENT
+          gh pr comment ${PR_NUMBER} \
+            --body-file body.md \
+            --repo ${PR_REPOSITORY}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -48,3 +48,36 @@ jobs:
           set -x
           path=$(python -c 'from openarm_mujoco.v2 import openarm_cell_xml; print(openarm_cell_xml())')
           [ -f "${path}" ]
+  web-node:
+    name: Web (Node)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    defaults:
+      run:
+        working-directory: web
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: web/package-lock.json
+      - run: npm ci
+      - run: npm test
+  web-browser:
+    name: Web (Browser)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    defaults:
+      run:
+        working-directory: web
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: web/package-lock.json
+      - run: npm ci
+      - run: npx playwright install --with-deps chromium
+      - run: npm run test:browser

--- a/.gitignore
+++ b/.gitignore
@@ -17,4 +17,7 @@
 *.pyc
 .DS_Store
 /build/
+/web/node_modules/
+/web/playwright-report/
+/web/test-results/
 __pycache__/

--- a/README.md
+++ b/README.md
@@ -29,6 +29,15 @@ With Wall Collisions:
 openarm-mujoco-launch --walls
 ```
 
+## OpenArm MuJoCo Web
+
+[OpenArm MuJoCo Web](web/README.md) runs these models right in the
+browser (MuJoCo WASM + three.js, no installation): open
+<https://enactic.github.io/openarm_mujoco/>, or serve the repository
+root locally (`npm run serve` in `web/`) and open
+<http://localhost:8080/>. Drive the arms by keyboard or sliders; see
+[web/README.md](web/README.md) for details.
+
 ## Collision Visualization
 - To view collision meshes, activate `Rendering`>`Model Elements`>`Convex Hull` and `Group Enable`>`Geom groups`>`Geom 3` in the left sidebar
 - It may also help to hide the visual meshes by deselecting `Geom 2`
@@ -38,6 +47,22 @@ openarm-mujoco-launch --walls
 - 📚 Read the [documentation](https://docs.openarm.dev/simulation/mujoco)
 - 💬 Join the community on [Discord](https://discord.gg/FsZaZ4z3We)
 - 📬 Contact us through <openarm@enactic.ai>
+
+## Pull request and preview
+
+You can enable preview on your fork by the following:
+
+1. Enable GitHub Pages on your fork:
+   1. Open https://github.com/${YOUR_GITHUB_ACCOUNT}/openarm_mujoco/settings/pages
+   2. Select "GitHub Actions" as "Source"
+2. Accept publishing GitHub Pages from all branches on your fork:
+   1. Open https://github.com/${YOUR_GITHUB_ACCOUNT}/openarm_mujoco/settings/environments
+   2. Select the "github-pages" environment
+   3. Change the default "Deployment branches and tags" rule:
+      1. Press the "Edit" button
+      2. Change the "Name pattern" to `*` from `main`
+
+You can preview your changes at https://${YOUR_GITHUB_ACCOUNT}.github.io/openarm_mujoco/ .
 
 ## License
 

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -1,0 +1,19 @@
+// Copyright 2026 Enactic, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{
+  "formatter": {
+    "indentStyle": "space"
+  }
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<!--
+  Copyright 2026 Enactic, Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>OpenArm MuJoCo Web</title>
+    <style>
+      body { margin: 0; overflow: hidden; font-family: system-ui, sans-serif; }
+      #panel {
+        position: fixed; top: 10px; left: 10px; width: 270px;
+        background: rgba(255, 255, 255, 0.92); border-radius: 8px;
+        padding: 10px 14px; font-size: 12px; max-height: calc(100vh - 40px);
+        overflow-y: auto; box-shadow: 0 2px 8px rgba(0,0,0,0.25);
+      }
+      #panel h3 { margin: 4px 0 6px; font-size: 13px; }
+      #status { margin-top: 8px; white-space: pre; font-family: monospace; font-size: 11px; }
+      #help { font-size: 10px; margin: 4px 0; }
+      button { margin-right: 6px; }
+    </style>
+  </head>
+  <body>
+    <div id="panel">
+      <h3>OpenArm MuJoCo Web</h3>
+      <div style="margin-bottom: 6px">
+        <select id="scene-select" style="max-width: 100%"></select>
+      </div>
+      <div>
+        <button id="reset-button">Reset</button>
+      </div>
+      <details open>
+        <summary>key bindings</summary>
+        <pre id="help"></pre>
+      </details>
+      <div id="status">loading…</div>
+    </div>
+    <script>
+      // Build the import map at runtime from web/package-lock.json, so the
+      // page and the tests always use the same dependency versions and there
+      // is a single place to bump them. The import map just has to be
+      // registered before any module resolution starts, which this loader
+      // guarantees by inserting the module script afterwards.
+      (async () => {
+        try {
+          const lock = await (await fetch("web/package-lock.json")).json();
+          const v = (name) => lock.packages[`node_modules/${name}`].version;
+          const importmap = document.createElement("script");
+          importmap.type = "importmap";
+          importmap.textContent = JSON.stringify({
+            imports: {
+              "three": `https://cdn.jsdelivr.net/npm/three@${v("three")}/build/three.module.js`,
+              "three/examples/jsm/controls/OrbitControls.js":
+                `https://cdn.jsdelivr.net/npm/three@${v("three")}/examples/jsm/controls/OrbitControls.js`,
+              "@mujoco/mujoco":
+                `https://cdn.jsdelivr.net/npm/@mujoco/mujoco@${v("@mujoco/mujoco")}/mujoco.js`,
+            },
+          });
+          document.head.appendChild(importmap);
+          const main = document.createElement("script");
+          main.type = "module";
+          main.src = "web/main.js";
+          document.head.appendChild(main);
+        } catch (e) {
+          document.getElementById("status").textContent = `load failed: ${e.message ?? e}`;
+          throw e;
+        }
+      })();
+    </script>
+  </body>
+</html>

--- a/v2/scenes.json
+++ b/v2/scenes.json
@@ -1,0 +1,25 @@
+{
+  "default": "cell/demo.xml",
+  "scenes": [
+    "openarm_bimanual.xml",
+    "cell/cell.xml",
+    "cell/demo.xml",
+    "cell/articulated_cell_scene.xml",
+    "cell/bottle_cell_scene.xml",
+    "cell/move_puck_cell_scene.xml",
+    "cell/peg_socket_cell_scene.xml",
+    "cell/tool_cell_scene.xml",
+    "cell/valve_cell_scene.xml",
+    "pedestal/pedestal.xml",
+    "pedestal/articulated_scene.xml",
+    "pedestal/balance_scene.xml",
+    "pedestal/bottle_scene.xml",
+    "pedestal/catch_scene.xml",
+    "pedestal/move_puck_scene.xml",
+    "pedestal/peg_socket_scene.xml",
+    "pedestal/throw_scene.xml",
+    "pedestal/throw_multi_scene.xml",
+    "pedestal/tool_scene.xml",
+    "pedestal/valve_scene.xml"
+  ]
+}

--- a/web/README.md
+++ b/web/README.md
@@ -1,0 +1,74 @@
+# OpenArm MuJoCo Web
+
+OpenArm MuJoCo Web runs the OpenArm bimanual robot in the browser: open
+the page and try the robot — no installation needed. Physics is
+simulated with the official MuJoCo WASM bindings (`@mujoco/mujoco`), and
+the arms are driven by end-effector **pose** (position + orientation)
+instead of qpos.
+
+How it works:
+
+1. `ik.js` — `PoseController` runs damped-least-squares differential IK on a
+   kinematics-only `MjData` scratch state (`mj_kinematics` + `mj_comPos` +
+   `mj_jacSite`), yielding joint targets for a requested pose of the
+   `left_ee_control_point` / `right_ee_control_point` sites.
+2. The joint targets feed the model's position actuators via `data.ctrl`.
+3. Gravity/bias compensation (`qfrc_applied = qfrc_bias` on the arm dofs)
+   removes steady-state sag from the low-gain actuators.
+
+The scene XMLs and mesh assets are fetched from the repository's `v2/`
+directory into an `MjVFS`, following each XML's `<model file>` /
+`meshdir` references recursively. A dropdown switches between all v2
+scenes (`openarm_bimanual.xml`, `cell/*`, `pedestal/*`); each starts from
+its `home` keyframe (or the IK home solution when the scene has none),
+and Backspace returns to that scene's own home pose. Cell scenes have a
+lifter (no UI control yet — a keyboard binding is planned), and the cell
+enclosure is drawn see-through.
+
+## Usage
+
+There is no build step or bundler: the page is plain HTML + ES modules.
+The page itself is the repository top-level `index.html`; the modules it
+loads live in `web/`. `three` and `@mujoco/mujoco` (including
+`mujoco.wasm`) are loaded from the jsDelivr npm CDN via an import map
+that `index.html` builds at runtime from `web/package-lock.json` — the
+lockfile is the single source for dependency versions, shared with the
+tests below. Any static file server works and no npm install is needed
+to run the page. Serve the **repository root** (the page fetches models
+from `v2/`):
+
+```sh
+npm run serve  # node serve.mjs: serves the repo root on port 8080
+# then open http://localhost:8080/
+```
+
+`npm install` is only needed for the tests below (it pulls the same
+pinned `three` / `@mujoco/mujoco` versions for Node, plus Playwright).
+
+Drive the arms with the keyboard (same bindings and semantics as
+[dora-openarm-keyboard](https://github.com/enactic/dora-openarm-keyboard):
+hold to move, tool-frame rotation, `+`/`-` speed scale, `Backspace` to
+return home, and losing tab focus releases every held key). `keymap.js` and
+`teleop.js` are direct ports of dora-openarm-keyboard's `keymap.py` and
+`teleop.py`, including its home pose (`0.216 ±0.1535 -0.22`, rpy
+`0 -90 0` in the `arm_origin` frame); the simulation starts from the IK
+solution of that pose.
+
+| | Left arm | Right arm |
+|---|---|---|
+| +X / -X | W / S | U / J |
+| +Y / -Y | A / D | H / K |
+| +Z / -Z | R / F | O / L |
+| +Pitch / -Pitch | E / C | I / , |
+| +Yaw / -Yaw | Q / Z | Y / N |
+| +Roll / -Roll | T / B | P / / |
+| Gripper close / open | G / V | ; / . |
+
+## Tests
+
+```sh
+npm test              # node:test-based headless tests: IK convergence,
+                      # teleop semantics, and every scene loading
+npm run test:browser  # Playwright end-to-end test (starts serve.mjs itself);
+                      # first run: npx playwright install chromium
+```

--- a/web/browser.spec.mjs
+++ b/web/browser.spec.mjs
@@ -1,0 +1,162 @@
+// Copyright 2026 Enactic, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// End-to-end test of OpenArm MuJoCo Web with Playwright. The webServer entry
+// in playwright.config.js starts serve.mjs automatically.
+//
+// The tests replay one continuous teleop session on a shared page (serial
+// mode): loading the MuJoCo WASM scene is expensive, so they build on each
+// other instead of reloading per test.
+import { expect, test } from "@playwright/test";
+
+test.describe.configure({ mode: "serial" });
+
+let page;
+
+const leftEE = () =>
+  page.evaluate(() => {
+    const s = window.__app.mjData.site_xpos;
+    const id = window.__app.controller.arms.left.siteId;
+    return [s[id * 3], s[id * 3 + 1], s[id * 3 + 2]];
+  });
+const rightEE = () =>
+  page.evaluate(() => {
+    const s = window.__app.mjData.site_xpos;
+    const id = window.__app.controller.arms.right.siteId;
+    return [s[id * 3], s[id * 3 + 1], s[id * 3 + 2]];
+  });
+// Largest target-tracking error shown in the status panel, in mm. Once it is
+// small the arms have settled on their current targets.
+const maxTrackError = async () => {
+  const text = await page.locator("#status").textContent();
+  const errors = [...text.matchAll(/error:\s+([\d.]+) mm/g)].map((m) =>
+    Number(m[1]),
+  );
+  return errors.length === 2 ? Math.max(...errors) : Infinity;
+};
+const settle = () =>
+  expect.poll(maxTrackError, { timeout: 20_000 }).toBeLessThan(1.0);
+
+test.beforeAll(async ({ browser }) => {
+  page = await browser.newPage();
+  page.on("pageerror", (e) => {
+    throw new Error(`page error: ${e}`);
+  });
+  await page.goto("/");
+  await expect(page.locator("#status")).toContainText("error", {
+    timeout: 60_000,
+  });
+  await settle();
+});
+
+test.afterAll(() => page?.close());
+
+test("holding W moves the left EE straight +x, right EE stays", async () => {
+  const before = await leftEE();
+  const beforeRight = await rightEE();
+  await page.keyboard.down("w");
+  await expect
+    .poll(async () => (await leftEE())[0], { timeout: 20_000 })
+    .toBeGreaterThan(before[0] + 0.02);
+  await page.keyboard.up("w");
+  await settle();
+  const after = await leftEE();
+  expect(Math.abs(after[1] - before[1])).toBeLessThan(0.01);
+  expect(Math.abs(after[2] - before[2])).toBeLessThan(0.01);
+  const afterRight = await rightEE();
+  expect(Math.abs(afterRight[0] - beforeRight[0])).toBeLessThan(0.01);
+});
+
+test("holding O moves the right EE up", async () => {
+  const before = await rightEE();
+  await page.keyboard.down("o");
+  await page.keyboard.down(";"); // close the right gripper along the way
+  await expect
+    .poll(async () => (await rightEE())[2], { timeout: 20_000 })
+    .toBeGreaterThan(before[2] + 0.02);
+  await page.keyboard.up("o");
+  await page.keyboard.up(";");
+  await settle();
+});
+
+test("Backspace returns both arms home", async () => {
+  const home = await page.evaluate(() => {
+    const { pos } = window.__app.targets.left;
+    return pos;
+  });
+  await page.keyboard.press("Backspace");
+  await settle();
+  // after reset the target is the home pose again; the EE must be back on it
+  const ee = await leftEE();
+  const target = await page.evaluate(() => window.__app.targets.left.pos);
+  expect(Math.hypot(...ee.map((v, i) => v - target[i]))).toBeLessThan(0.01);
+  expect(target).not.toEqual(home); // W/O session had moved the target
+});
+
+test("the lifter carries the arms up, Backspace resets it", async () => {
+  const before = await leftEE();
+  await page.evaluate(() => {
+    window.__app.lifterHeight = 0.15; // no UI control yet
+  });
+  await expect
+    .poll(async () => (await leftEE())[2], { timeout: 20_000 })
+    .toBeGreaterThan(before[2] + 0.1);
+  // Backspace performs the same full reset as the Reset button, lifter
+  // included.
+  await page.keyboard.press("Backspace");
+  await expect
+    .poll(() => page.evaluate(() => window.__app.lifterHeight))
+    .toBe(0);
+  await settle();
+});
+
+test("teleop still works after switching scenes", async () => {
+  await page.selectOption("#scene-select", "pedestal/bottle_scene.xml");
+  await page.waitForFunction(
+    () =>
+      window.__app.scenePath === "pedestal/bottle_scene.xml" &&
+      window.__app.mjModel,
+    { timeout: 60_000 },
+  );
+  await settle();
+  const before = await leftEE();
+  await page.keyboard.down("r"); // left arm up
+  await expect
+    .poll(async () => (await leftEE())[2], { timeout: 20_000 })
+    .toBeGreaterThan(before[2] + 0.008);
+  await page.keyboard.up("r");
+});
+
+// Keep these last: the failed load intentionally leaves the app without a
+// loaded scene, and the next test checks that state.
+test("a missing model file fails with its name, not a parse error", async () => {
+  const message = await page.evaluate(() =>
+    window.__app.loadScene("does-not-exist.xml").then(
+      () => "resolved",
+      (e) => String(e.message ?? e),
+    ),
+  );
+  expect(message).toContain("does-not-exist.xml");
+  expect(message).toContain("404");
+  // a failed load must leave no partial scene behind
+  expect(await page.evaluate(() => window.__app.mjModel)).toBeNull();
+});
+
+test("Backspace while no scene is loaded is ignored", async () => {
+  // Regression: reset() used to call into the null controller and throw
+  // (which the pageerror hook above would turn into a test failure).
+  await page.keyboard.press("Backspace");
+  await page.waitForTimeout(100);
+  expect(await page.evaluate(() => window.__app.controller)).toBeNull();
+});

--- a/web/ik.js
+++ b/web/ik.js
@@ -1,0 +1,449 @@
+// Copyright 2026 Enactic, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Pose-based control for OpenArm on the MuJoCo WASM bindings.
+//
+// PoseController owns a kinematics-only MjData used as an IK scratch space:
+// solve() runs damped-least-squares IK there and returns exact joint targets
+// for a requested end-effector pose, without touching the simulation state.
+
+function mat2quat(m) {
+  const q = [0, 0, 0, 0];
+  const tr = m[0] + m[4] + m[8];
+  if (tr > 0) {
+    const s = Math.sqrt(tr + 1) * 2;
+    q[0] = 0.25 * s;
+    q[1] = (m[7] - m[5]) / s;
+    q[2] = (m[2] - m[6]) / s;
+    q[3] = (m[3] - m[1]) / s;
+  } else if (m[0] > m[4] && m[0] > m[8]) {
+    const s = Math.sqrt(1 + m[0] - m[4] - m[8]) * 2;
+    q[0] = (m[7] - m[5]) / s;
+    q[1] = 0.25 * s;
+    q[2] = (m[1] + m[3]) / s;
+    q[3] = (m[2] + m[6]) / s;
+  } else if (m[4] > m[8]) {
+    const s = Math.sqrt(1 + m[4] - m[0] - m[8]) * 2;
+    q[0] = (m[2] - m[6]) / s;
+    q[1] = (m[1] + m[3]) / s;
+    q[2] = 0.25 * s;
+    q[3] = (m[5] + m[7]) / s;
+  } else {
+    const s = Math.sqrt(1 + m[8] - m[0] - m[4]) * 2;
+    q[0] = (m[3] - m[1]) / s;
+    q[1] = (m[2] + m[6]) / s;
+    q[2] = (m[5] + m[7]) / s;
+    q[3] = 0.25 * s;
+  }
+  return q;
+}
+
+export function quatMul(a, b) {
+  return [
+    a[0] * b[0] - a[1] * b[1] - a[2] * b[2] - a[3] * b[3],
+    a[0] * b[1] + a[1] * b[0] + a[2] * b[3] - a[3] * b[2],
+    a[0] * b[2] - a[1] * b[3] + a[2] * b[0] + a[3] * b[1],
+    a[0] * b[3] + a[1] * b[2] - a[2] * b[1] + a[3] * b[0],
+  ];
+}
+
+function quatConj(q) {
+  return [q[0], -q[1], -q[2], -q[3]];
+}
+
+function quatRotVec(q, v) {
+  const [w, x, y, z] = q;
+  const [vx, vy, vz] = v;
+  // t = 2 q_vec x v; v' = v + w t + q_vec x t
+  const tx = 2 * (y * vz - z * vy);
+  const ty = 2 * (z * vx - x * vz);
+  const tz = 2 * (x * vy - y * vx);
+  return [
+    vx + w * tx + y * tz - z * ty,
+    vy + w * ty + z * tx - x * tz,
+    vz + w * tz + x * ty - y * tx,
+  ];
+}
+
+// Express a pose given in a local frame (e.g. the arm_origin site) in world
+// coordinates.
+export function poseLocalToWorld(origin, pos, quat) {
+  const p = quatRotVec(origin.quat, pos);
+  return {
+    pos: [origin.pos[0] + p[0], origin.pos[1] + p[1], origin.pos[2] + p[2]],
+    quat: quatMul(origin.quat, quat),
+  };
+}
+
+// Inverse of poseLocalToWorld.
+function poseWorldToLocal(origin, pos, quat) {
+  const inv = quatConj(origin.quat);
+  return {
+    pos: quatRotVec(inv, [
+      pos[0] - origin.pos[0],
+      pos[1] - origin.pos[1],
+      pos[2] - origin.pos[2],
+    ]),
+    quat: quatMul(inv, quat),
+  };
+}
+
+export function eulerZYXToQuat(roll, pitch, yaw) {
+  const cr = Math.cos(roll / 2),
+    sr = Math.sin(roll / 2);
+  const cp = Math.cos(pitch / 2),
+    sp = Math.sin(pitch / 2);
+  const cy = Math.cos(yaw / 2),
+    sy = Math.sin(yaw / 2);
+  return [
+    cr * cp * cy + sr * sp * sy,
+    sr * cp * cy - cr * sp * sy,
+    cr * sp * cy + sr * cp * sy,
+    cr * cp * sy - sr * sp * cy,
+  ];
+}
+
+// Rotation error as a world-frame rotation vector: log(q_target * q_current^-1)
+export function quatError(qTarget, qCurrent) {
+  let qe = quatMul(qTarget, quatConj(qCurrent));
+  if (qe[0] < 0) qe = qe.map((v) => -v);
+  const sin = Math.hypot(qe[1], qe[2], qe[3]);
+  if (sin < 1e-10) return [0, 0, 0];
+  const angle = 2 * Math.atan2(sin, qe[0]);
+  return [(qe[1] / sin) * angle, (qe[2] / sin) * angle, (qe[3] / sin) * angle];
+}
+
+// Solve (A + lambda2 I) x = b for symmetric 6x6 A, Gaussian elimination.
+function solve6(A, b, lambda2) {
+  const n = 6;
+  const M = A.map((row, i) => {
+    const r = [...row];
+    r[i] += lambda2;
+    r.push(b[i]);
+    return r;
+  });
+  for (let c = 0; c < n; c++) {
+    let piv = c;
+    for (let r = c + 1; r < n; r++)
+      if (Math.abs(M[r][c]) > Math.abs(M[piv][c])) piv = r;
+    [M[c], M[piv]] = [M[piv], M[c]];
+    for (let r = 0; r < n; r++) {
+      if (r === c || M[c][c] === 0) continue;
+      const f = M[r][c] / M[c][c];
+      for (let k = c; k <= n; k++) M[r][k] -= f * M[c][k];
+    }
+  }
+  return M.map((row, i) => row[n] / M[i][i]);
+}
+
+class Arm {
+  constructor(mujoco, model, side) {
+    this.side = side;
+    this.dofIds = [];
+    this.qposIds = [];
+    this.jntRanges = [];
+    for (let i = 1; i <= 7; i++) {
+      const j = model.jnt(`openarm_${side}_joint${i}`);
+      this.dofIds.push(Number(j.dofadr[0] ?? j.dofadr));
+      this.qposIds.push(Number(j.qposadr[0] ?? j.qposadr));
+      this.jntRanges.push([j.range[0], j.range[1]]);
+      j.delete();
+    }
+    this.actIds = [];
+    for (let i = 1; i <= 7; i++) {
+      const a = model.actuator(`${side}_joint${i}_ctrl`);
+      this.actIds.push(a.id);
+      a.delete();
+    }
+    const g = model.actuator(`${side}_finger1_ctrl`);
+    this.gripperActId = g.id;
+    this.gripperRange = [g.ctrlrange[0], g.ctrlrange[1]];
+    g.delete();
+    this.siteId = mujoco.mj_name2id(
+      model,
+      mujoco.mjtObj.mjOBJ_SITE.value,
+      `${side}_ee_control_point`,
+    );
+  }
+
+  pose(data) {
+    const p = data.site_xpos.subarray(this.siteId * 3, this.siteId * 3 + 3);
+    const m = data.site_xmat.subarray(this.siteId * 9, this.siteId * 9 + 9);
+    return { pos: [...p], quat: mat2quat(m) };
+  }
+
+  poseError(data, targetPos, targetQuat) {
+    const { pos, quat } = this.pose(data);
+    return {
+      errorP: [
+        targetPos[0] - pos[0],
+        targetPos[1] - pos[1],
+        targetPos[2] - pos[2],
+      ],
+      errorR: quatError(targetQuat, quat),
+    };
+  }
+}
+
+export class PoseController {
+  constructor(mujoco, model) {
+    this.mujoco = mujoco;
+    this.model = model;
+    this.nv = model.nv;
+    this.ikData = new mujoco.MjData(model);
+    this.jacp = new mujoco.DoubleBuffer(3 * this.nv);
+    this.jacr = new mujoco.DoubleBuffer(3 * this.nv);
+    try {
+      this.arms = {
+        left: new Arm(mujoco, model, "left"),
+        right: new Arm(mujoco, model, "right"),
+      };
+      // Pose targets are expressed in the arm_origin site frame; -1 (absent)
+      // means the model root is the origin and targets are world coordinates.
+      this.originSiteId = mujoco.mj_name2id(
+        model,
+        mujoco.mjtObj.mjOBJ_SITE.value,
+        "arm_origin",
+      );
+      // Optional lifter (cell scenes): the arms ride on a vertical slide
+      // joint.
+      this.lifterDofId = -1;
+      this.lifterActId = -1;
+      const lifterJointId = mujoco.mj_name2id(
+        model,
+        mujoco.mjtObj.mjOBJ_JOINT.value,
+        "openarm_lifter_joint",
+      );
+      this.lifterQposId = -1;
+      if (lifterJointId >= 0) {
+        const j = model.jnt(lifterJointId);
+        this.lifterDofId = Number(j.dofadr[0] ?? j.dofadr);
+        this.lifterQposId = Number(j.qposadr[0] ?? j.qposadr);
+        j.delete();
+        const a = model.actuator("lifter_ctrl");
+        this.lifterActId = a.id;
+        a.delete();
+      }
+    } catch (e) {
+      // e.g. a model without the openarm_{side}_joint1..7 naming: free the
+      // buffers allocated above instead of leaking them in the WASM heap.
+      this.dispose();
+      throw e;
+    }
+  }
+
+  // World pose of the arm_origin site (identity if the model has none).
+  originPose(data) {
+    if (this.originSiteId < 0) return { pos: [0, 0, 0], quat: [1, 0, 0, 0] };
+    const p = data.site_xpos.subarray(
+      this.originSiteId * 3,
+      this.originSiteId * 3 + 3,
+    );
+    const m = data.site_xmat.subarray(
+      this.originSiteId * 9,
+      this.originSiteId * 9 + 9,
+    );
+    return { pos: [...p], quat: mat2quat(m) };
+  }
+
+  dispose() {
+    this.jacr.delete();
+    this.jacp.delete();
+    this.ikData.delete();
+  }
+
+  // Seed the IK scratch state from the simulation state.
+  syncFrom(data) {
+    this.ikData.qpos.set(data.qpos);
+    this.lastCommands = {}; // the IK seed changed; cached solutions are stale
+  }
+
+  // Damped-least-squares IK on the scratch state; returns 7 joint targets.
+  solve(
+    side,
+    targetPos,
+    targetQuat,
+    { iters = 50, tol = 1e-5, maxStep = 0.2, lambda2 = 1e-6 } = {},
+  ) {
+    const { mujoco, model, ikData, nv } = this;
+    const arm = this.arms[side];
+    const qpos = ikData.qpos;
+    for (let it = 0; it < iters; it++) {
+      mujoco.mj_kinematics(model, ikData);
+      mujoco.mj_comPos(model, ikData);
+      const { errorP, errorR } = arm.poseError(ikData, targetPos, targetQuat);
+      if (Math.hypot(...errorP) < tol && Math.hypot(...errorR) < 10 * tol)
+        break;
+      const error = [...errorP, ...errorR];
+
+      mujoco.mj_jacSite(model, ikData, this.jacp, this.jacr, arm.siteId);
+      const Jp = this.jacp.GetView();
+      const Jr = this.jacr.GetView();
+      const J = [];
+      for (let r = 0; r < 3; r++) J.push(arm.dofIds.map((d) => Jp[r * nv + d]));
+      for (let r = 0; r < 3; r++) J.push(arm.dofIds.map((d) => Jr[r * nv + d]));
+      const A = [];
+      for (let i = 0; i < 6; i++) {
+        A.push([]);
+        for (let j = 0; j < 6; j++) {
+          let s = 0;
+          for (let k = 0; k < 7; k++) s += J[i][k] * J[j][k];
+          A[i].push(s);
+        }
+      }
+      const y = solve6(A, error, lambda2);
+      for (let k = 0; k < 7; k++) {
+        let s = 0;
+        for (let i = 0; i < 6; i++) s += J[i][k] * y[i];
+        s = Math.min(maxStep, Math.max(-maxStep, s));
+        const [lo, hi] = arm.jntRanges[k];
+        qpos[arm.qposIds[k]] = Math.min(
+          hi,
+          Math.max(lo, qpos[arm.qposIds[k]] + s),
+        );
+      }
+    }
+    return arm.qposIds.map((i) => qpos[i]);
+  }
+
+  // Solve IK for a pose target and write the joint targets to data.ctrl.
+  command(data, side, targetPos, targetQuat) {
+    // keep the IK scratch state's lifter in step with the simulation, so a
+    // world target that already includes the lifted arm_origin is not reached
+    // a second time by stretching the arm
+    if (this.lifterQposId >= 0) {
+      this.ikData.qpos[this.lifterQposId] = data.qpos[this.lifterQposId];
+    }
+    const arm = this.arms[side];
+    const q = this.solve(side, targetPos, targetQuat);
+    q.forEach((v, i) => {
+      data.ctrl[arm.actIds[i]] = v;
+    });
+    return q;
+  }
+
+  commandGripper(data, side, openRatio) {
+    const arm = this.arms[side];
+    const [lo, hi] = arm.gripperRange;
+    // For both arms ratio 0 = closed (ctrl 0), 1 = fully open (range end away from 0)
+    const end = Math.abs(lo) > Math.abs(hi) ? lo : hi;
+    data.ctrl[arm.gripperActId] = end * openRatio;
+  }
+
+  commandLifter(data, height) {
+    if (this.lifterActId >= 0) data.ctrl[this.lifterActId] = height;
+  }
+
+  // Reset to the scene's first keyframe, with the position actuators holding
+  // that pose (ctrl = qpos): without it they would drive every joint toward
+  // 0 rad on the first step.
+  startFromKeyframe(data) {
+    const { mujoco, model } = this;
+    mujoco.mj_resetDataKeyframe(model, data, 0);
+    mujoco.mj_forward(model, data);
+    for (const side of ["left", "right"]) {
+      const arm = this.arms[side];
+      for (let i = 0; i < 7; i++) {
+        data.ctrl[arm.actIds[i]] = data.qpos[arm.qposIds[i]];
+      }
+    }
+  }
+
+  // Reset to the IK solution of teleop's home pose, with the position
+  // actuators holding it — for scenes that define no keyframe.
+  startFromTeleopHome(data, teleop) {
+    const { mujoco, model } = this;
+    mujoco.mj_resetData(model, data);
+    mujoco.mj_forward(model, data);
+    this.syncFrom(data);
+    const origin = this.originPose(data);
+    for (const side of ["left", "right"]) {
+      const arm = teleop.arms[side];
+      const { pos, quat } = poseLocalToWorld(origin, arm.pos, arm.quat);
+      this.solve(side, pos, quat, { iters: 300 });
+    }
+    data.qpos.set(this.ikData.qpos);
+    data.qvel.fill(0);
+    mujoco.mj_forward(model, data);
+    for (const side of ["left", "right"]) {
+      const arm = this.arms[side];
+      for (let i = 0; i < 7; i++) {
+        data.ctrl[arm.actIds[i]] = data.qpos[arm.qposIds[i]];
+      }
+    }
+  }
+
+  // Reset to the scene's start pose: the `home` keyframe when the model has
+  // one (its end-effector pose in the arm_origin frame is the teleop home
+  // pose, same contract as dora-openarm-keyboard), otherwise the IK solution
+  // of teleop's home pose. The measured start pose becomes teleop's home, so
+  // the first tick never yanks and a teleop reset returns here.
+  startFromHome(data, teleop) {
+    if (this.model.nkey > 0) this.startFromKeyframe(data);
+    else this.startFromTeleopHome(data, teleop);
+    this.syncFrom(data);
+    const origin = this.originPose(data);
+    for (const side of ["left", "right"]) {
+      const { pos, quat } = this.arms[side].pose(data);
+      const local = poseWorldToLocal(origin, pos, quat);
+      teleop.arms[side].setHome(local.pos, local.quat);
+    }
+  }
+
+  // Send teleop's current targets (expressed in the arm_origin frame) to the
+  // actuators. Returns each side's world target for callers that need it.
+  //
+  // The joint solution depends only on the arm_origin-frame target (the arm
+  // rides on the lifter together with its target), so an unchanged target
+  // reuses the previous solution. Without this, an out-of-reach target —
+  // teleop clamps positions at ±0.8 m, beyond the arm's reach — would never
+  // converge and would cost the full IK iteration budget for both arms on
+  // every frame, forever.
+  applyTeleop(data, teleop, lifterHeight = 0) {
+    this.commandLifter(data, lifterHeight);
+    const origin = this.originPose(data);
+    const targets = {};
+    this.lastCommands ??= {};
+    for (const side of ["left", "right"]) {
+      const arm = teleop.arms[side];
+      const target = poseLocalToWorld(origin, arm.pos, arm.quat);
+      const last = this.lastCommands[side];
+      if (
+        last?.pos.every((v, i) => v === arm.pos[i]) &&
+        last.quat.every((v, i) => v === arm.quat[i])
+      ) {
+        last.q.forEach((v, i) => {
+          data.ctrl[this.arms[side].actIds[i]] = v;
+        });
+      } else {
+        const q = this.command(data, side, target.pos, target.quat);
+        this.lastCommands[side] = { pos: [...arm.pos], quat: [...arm.quat], q };
+      }
+      this.commandGripper(data, side, 1 - arm.grip);
+      targets[side] = target;
+    }
+    return targets;
+  }
+
+  // Gravity/bias compensation so the low-gain position actuators do not sag.
+  applyGravityComp(data) {
+    for (const side of ["left", "right"]) {
+      for (const d of this.arms[side].dofIds)
+        data.qfrc_applied[d] = data.qfrc_bias[d];
+    }
+    if (this.lifterDofId >= 0) {
+      data.qfrc_applied[this.lifterDofId] = data.qfrc_bias[this.lifterDofId];
+    }
+  }
+}

--- a/web/keymap.js
+++ b/web/keymap.js
@@ -1,0 +1,88 @@
+// Copyright 2026 Enactic, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Key bindings for keyboard teleoperation, ported from
+// dora-openarm-keyboard (src/dora_openarm_keyboard/keymap.py).
+//
+// The left half of the keyboard drives the left arm and the right half the
+// right arm. Both halves use the same geometric shape, shifted five columns
+// across, so each pair straddles its home-row anchor identically.
+
+export const LINEAR = "linear";
+export const ANGULAR = "angular";
+export const GRIP = "grip";
+
+export const LEFT = "left";
+export const RIGHT = "right";
+
+// Axis indices shared by LINEAR (x, y, z) and ANGULAR (roll, pitch, yaw).
+const X = 0,
+  Y = 1,
+  Z = 2;
+const ROLL = 0,
+  PITCH = 1,
+  YAW = 2;
+
+// key -> [arm, kind, axis, sign]. For GRIP, sign +1 closes and -1 opens.
+export const KEYMAP = {
+  // left arm
+  w: [LEFT, LINEAR, X, +1],
+  s: [LEFT, LINEAR, X, -1],
+  a: [LEFT, LINEAR, Y, +1],
+  d: [LEFT, LINEAR, Y, -1],
+  r: [LEFT, LINEAR, Z, +1],
+  f: [LEFT, LINEAR, Z, -1],
+  e: [LEFT, ANGULAR, PITCH, +1],
+  c: [LEFT, ANGULAR, PITCH, -1],
+  q: [LEFT, ANGULAR, YAW, +1],
+  z: [LEFT, ANGULAR, YAW, -1],
+  t: [LEFT, ANGULAR, ROLL, +1],
+  b: [LEFT, ANGULAR, ROLL, -1],
+  g: [LEFT, GRIP, 0, +1],
+  v: [LEFT, GRIP, 0, -1],
+  // right arm
+  u: [RIGHT, LINEAR, X, +1],
+  j: [RIGHT, LINEAR, X, -1],
+  h: [RIGHT, LINEAR, Y, +1],
+  k: [RIGHT, LINEAR, Y, -1],
+  o: [RIGHT, LINEAR, Z, +1],
+  l: [RIGHT, LINEAR, Z, -1],
+  i: [RIGHT, ANGULAR, PITCH, +1],
+  ",": [RIGHT, ANGULAR, PITCH, -1],
+  y: [RIGHT, ANGULAR, YAW, +1],
+  n: [RIGHT, ANGULAR, YAW, -1],
+  p: [RIGHT, ANGULAR, ROLL, +1],
+  "/": [RIGHT, ANGULAR, ROLL, -1],
+  ";": [RIGHT, GRIP, 0, +1],
+  ".": [RIGHT, GRIP, 0, -1],
+};
+
+// Edge-triggered control keys, handled on key-down rather than while held.
+export const RESET_KEY = "backspace";
+export const SPEED_UP_KEYS = ["+", "="];
+export const SPEED_DOWN_KEYS = ["-", "_"];
+
+export const HELP_TEXT = `\
+              LEFT ARM (left hand)   RIGHT ARM (right hand)
+  +X / -X          W / S                    U / J
+  +Y / -Y          A / D                    H / K
+  +Z / -Z          R / F                    O / L
+  +Pitch / -Pitch  E / C                    I / ,
+  +Yaw   / -Yaw    Q / Z                    Y / N
+  +Roll  / -Roll   T / B                    P / /
+  gripper close    G                        ;
+  gripper open     V                        .
+
+  + / -      speed scale up / down
+  Backspace  reset to the home pose`;

--- a/web/load-model.mjs
+++ b/web/load-model.mjs
@@ -1,0 +1,41 @@
+// Copyright 2026 Enactic, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Node-side wrapper for the shared VFS walker (model-vfs.js): load a v2
+// scene from the repository checkout via fs, by the same rules the browser
+// app uses.
+import fs from "node:fs";
+import path from "node:path";
+import { DOMParser } from "@xmldom/xmldom";
+import { buildVFS } from "./model-vfs.js";
+
+const V2_DIR = path.resolve(import.meta.dirname, "../v2");
+
+export async function loadSceneModel(mujoco, scenePath) {
+  const vfs = await buildVFS(
+    mujoco,
+    scenePath,
+    async (p) => new Uint8Array(fs.readFileSync(path.join(V2_DIR, p))),
+    DOMParser,
+  );
+  try {
+    return mujoco.MjModel.from_xml_path(scenePath, vfs);
+  } finally {
+    vfs.delete();
+  }
+}
+
+export function loadCellModel(mujoco) {
+  return loadSceneModel(mujoco, "cell/cell.xml");
+}

--- a/web/main.js
+++ b/web/main.js
@@ -1,0 +1,519 @@
+// Copyright 2026 Enactic, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import loadMuJoCo from "@mujoco/mujoco";
+// OpenArm MuJoCo Web: try the OpenArm in the browser, no installation needed,
+// simulated with the MuJoCo WASM bindings.
+//
+// The end effectors are driven by pose (position + orientation) targets, not
+// by qpos: PoseController (ik.js) solves damped-least-squares IK on a
+// kinematics-only MjData and feeds the resulting joint targets to the model's
+// position actuators.
+//
+// The pose targets come from TeleopState (teleop.js), which integrates held
+// keys exactly like dora-openarm-keyboard: hold to move, tool-frame rotation,
+// +/- speed scaling, Backspace to return home.
+import * as THREE from "three";
+import { OrbitControls } from "three/examples/jsm/controls/OrbitControls.js";
+import { PoseController } from "./ik.js";
+import {
+  HELP_TEXT,
+  KEYMAP,
+  RESET_KEY,
+  SPEED_DOWN_KEYS,
+  SPEED_UP_KEYS,
+} from "./keymap.js";
+import { buildVFS } from "./model-vfs.js";
+import { TeleopState } from "./teleop.js";
+
+let mujoco;
+
+const SIDES = ["left", "right"];
+
+// Scene and asset files are fetched straight from the repository's v2/
+// directory. The path is resolved against the page URL (index.html at
+// the repository root), so serve the repository root.
+const MODEL_BASE = "v2/";
+
+// fetch() resolves on HTTP errors, so check ok here: a missing model file
+// must fail with its name, not as a later, unrelated MuJoCo parse error on
+// the 404 body.
+async function fetchModelFile(path) {
+  const res = await fetch(MODEL_BASE + path);
+  if (!res.ok) throw new Error(`${path}: ${res.status} ${res.statusText}`);
+  return res;
+}
+
+const fetchModelBytes = async (path) =>
+  new Uint8Array(await (await fetchModelFile(path)).arrayBuffer());
+
+class App {
+  constructor() {
+    this.mjvPerturb = new mujoco.MjvPerturb();
+    this.mjvOption = new mujoco.MjvOption();
+    this.mjvCamera = new mujoco.MjvCamera();
+    this.maxGeoms = 2 ** 14;
+    this.meshes = [];
+    this.bufferGeometryCache = new Map();
+    this.teleop = new TeleopState();
+    this.held = new Set();
+    this.lifterHeight = 0;
+    this.statusElement = document.getElementById("status");
+
+    this.scene = new THREE.Scene();
+    this.scene.background = new THREE.Color(0x263238);
+
+    this.renderer = new THREE.WebGLRenderer({ antialias: true });
+    this.renderer.setSize(window.innerWidth, window.innerHeight);
+    document.body.appendChild(this.renderer.domElement);
+
+    this.camera = new THREE.PerspectiveCamera(
+      45,
+      window.innerWidth / window.innerHeight,
+      0.01,
+      100,
+    );
+    this.camera.up.set(0, 0, 1); // MuJoCo is z-up
+    this.camera.position.set(2.0, -1.3, 1.9); // 3/4 view into the cell
+
+    this.controls = new OrbitControls(this.camera, this.renderer.domElement);
+    this.controls.target.set(0.4, 0, 1.15);
+    this.initLights();
+
+    window.addEventListener("resize", () => {
+      this.camera.aspect = window.innerWidth / window.innerHeight;
+      this.camera.updateProjectionMatrix();
+      this.renderer.setSize(window.innerWidth, window.innerHeight);
+    });
+  }
+
+  disposeScene() {
+    for (const mesh of this.meshes) {
+      this.scene.remove(mesh);
+      mesh.material.dispose();
+    }
+    this.meshes = [];
+    for (const geom of this.bufferGeometryCache.values()) geom.dispose();
+    this.bufferGeometryCache.clear();
+    if (this.markers) {
+      for (const side of SIDES) this.scene.remove(this.markers[side]);
+      this.markers = null;
+    }
+    this.mjvScene?.delete();
+    this.mjvScene = null;
+    this.controller?.dispose();
+    this.controller = null;
+    this.mjData?.delete();
+    this.mjData = null;
+    this.mjModel?.delete();
+    this.mjModel = null;
+  }
+
+  async loadScene(scenePath) {
+    this.disposeScene();
+    this.scenePath = scenePath;
+    this.teleop.reset();
+    this.lifterHeight = 0;
+    this.held.clear();
+
+    try {
+      const vfs = await buildVFS(mujoco, scenePath, fetchModelBytes, DOMParser);
+      try {
+        this.mjModel = mujoco.MjModel.from_xml_path(scenePath, vfs);
+      } finally {
+        vfs.delete();
+      }
+      this.mjData = new mujoco.MjData(this.mjModel);
+
+      this.controller = new PoseController(mujoco, this.mjModel);
+      this.startFromHome();
+
+      // the cell enclosure mesh is drawn see-through so the arms stay visible
+      this.transparentGeomIds = new Set();
+      const cellVis = mujoco.mj_name2id(
+        this.mjModel,
+        mujoco.mjtObj.mjOBJ_GEOM.value,
+        "cell_vis",
+      );
+      if (cellVis >= 0) this.transparentGeomIds.add(cellVis);
+
+      this.mjvScene = new mujoco.MjvScene(this.mjModel, this.maxGeoms);
+      this.initTargetMarkers();
+      this.frameCamera();
+    } catch (e) {
+      // A partially loaded scene must not survive: update()'s !mjModel guard
+      // only protects the render loop when a failure leaves no scene at all.
+      this.disposeScene();
+      throw e;
+    }
+  }
+
+  // Frame the camera like MuJoCo's default free camera, which is also what
+  // dora-openarm-mujoco sets explicitly for the cell scene: lookat at the
+  // model statistics center, azimuth/elevation from the scene's
+  // <visual><global>, distance of one model extent (dora uses 3.5 = the cell
+  // scene's extent).
+  frameCamera() {
+    const stat = this.mjModel.stat;
+    const g = this.mjModel.vis.global;
+    const az = (g.azimuth * Math.PI) / 180;
+    const el = (g.elevation * Math.PI) / 180;
+    g.delete?.();
+    const lookat = [...stat.center];
+    const d = Math.max(1.5, stat.extent);
+    const forward = [
+      Math.cos(el) * Math.cos(az),
+      Math.cos(el) * Math.sin(az),
+      Math.sin(el),
+    ];
+    this.camera.position.set(
+      lookat[0] - d * forward[0],
+      lookat[1] - d * forward[1],
+      lookat[2] - d * forward[2],
+    );
+    this.controls.target.set(...lookat);
+  }
+
+  startFromHome() {
+    this.simTarget = null; // mjData.time restarts from 0 below
+    this.controller.startFromHome(this.mjData, this.teleop);
+    this.applyTargets();
+  }
+
+  initLights() {
+    const ambient = new THREE.AmbientLight(0xffffff, 0.6);
+    this.scene.add(ambient);
+    const dir = new THREE.DirectionalLight(0xffffff, 1.2);
+    dir.position.set(2, 1, 2);
+    this.scene.add(dir);
+    const dir2 = new THREE.DirectionalLight(0xffffff, 0.5);
+    dir2.position.set(-2, -1, 1);
+    this.scene.add(dir2);
+  }
+
+  initTargetMarkers() {
+    this.markers = {};
+    for (const side of SIDES) {
+      const marker = new THREE.AxesHelper(0.08);
+      this.scene.add(marker);
+      this.markers[side] = marker;
+    }
+  }
+
+  applyTargets() {
+    // World targets, kept for the markers and the status display.
+    this.targets = this.controller.applyTeleop(
+      this.mjData,
+      this.teleop,
+      this.lifterHeight,
+    );
+    for (const side of SIDES) {
+      const m = this.markers?.[side];
+      if (m) {
+        const { pos, quat } = this.targets[side];
+        m.position.set(pos[0], pos[1], pos[2]);
+        m.quaternion.set(quat[1], quat[2], quat[3], quat[0]);
+      }
+    }
+  }
+
+  reset() {
+    if (!this.controller) return; // scene is loading (or failed to load)
+    this.teleop.reset();
+    this.lifterHeight = 0;
+    this.startFromHome();
+  }
+
+  // Build a THREE geometry for a MuJoCo mesh asset (non-indexed, flat faces).
+  meshGeometry(meshId) {
+    const m = this.mjModel;
+    const vertAdr = m.mesh_vertadr[meshId];
+    const faceAdr = m.mesh_faceadr[meshId];
+    const faceNum = m.mesh_facenum[meshId];
+    const normalAdr = m.mesh_normaladr[meshId];
+    const positions = new Float32Array(faceNum * 9);
+    const normals = new Float32Array(faceNum * 9);
+    for (let f = 0; f < faceNum; f++) {
+      for (let c = 0; c < 3; c++) {
+        const vi = m.mesh_face[(faceAdr + f) * 3 + c];
+        const ni = m.mesh_facenormal[(faceAdr + f) * 3 + c];
+        for (let k = 0; k < 3; k++) {
+          positions[f * 9 + c * 3 + k] = m.mesh_vert[(vertAdr + vi) * 3 + k];
+          normals[f * 9 + c * 3 + k] = m.mesh_normal[(normalAdr + ni) * 3 + k];
+        }
+      }
+    }
+    const geom = new THREE.BufferGeometry();
+    geom.setAttribute("position", new THREE.BufferAttribute(positions, 3));
+    geom.setAttribute("normal", new THREE.BufferAttribute(normals, 3));
+    return geom;
+  }
+
+  getBufferGeometry(mjvGeom) {
+    const key = JSON.stringify([
+      mjvGeom.type,
+      [...mjvGeom.size],
+      mjvGeom.dataid,
+    ]);
+    const found = this.bufferGeometryCache.get(key);
+    if (found) return found;
+
+    let geom;
+    const t = mujoco.mjtGeom;
+    if (mjvGeom.type === t.mjGEOM_MESH.value) {
+      // for mesh geoms dataid is 2*meshid, +1 when the convex hull is wanted
+      // (engine_vis_visualize.c); we always render the full mesh
+      geom = this.meshGeometry(mjvGeom.dataid >> 1);
+    } else if (mjvGeom.type === t.mjGEOM_PLANE.value) {
+      geom = new THREE.PlaneGeometry(
+        2 * (mjvGeom.size[0] || 10),
+        2 * (mjvGeom.size[1] || 10),
+      );
+    } else if (mjvGeom.type === t.mjGEOM_SPHERE.value) {
+      geom = new THREE.SphereGeometry(mjvGeom.size[0]);
+    } else if (mjvGeom.type === t.mjGEOM_CAPSULE.value) {
+      geom = new THREE.CapsuleGeometry(
+        mjvGeom.size[0],
+        2 * mjvGeom.size[2],
+        8,
+        16,
+      );
+      geom.rotateX(0.5 * Math.PI);
+    } else if (mjvGeom.type === t.mjGEOM_BOX.value) {
+      geom = new THREE.BoxGeometry(
+        2 * mjvGeom.size[0],
+        2 * mjvGeom.size[1],
+        2 * mjvGeom.size[2],
+      );
+    } else if (mjvGeom.type === t.mjGEOM_CYLINDER.value) {
+      geom = new THREE.CylinderGeometry(
+        mjvGeom.size[0],
+        mjvGeom.size[1],
+        2 * mjvGeom.size[2],
+        32,
+      );
+      geom.rotateX(0.5 * Math.PI);
+    } else {
+      geom = new THREE.BufferGeometry();
+    }
+    this.bufferGeometryCache.set(key, geom);
+    return geom;
+  }
+
+  update(dt) {
+    this.controls.update();
+    if (!this.mjModel) return; // scene is loading
+
+    this.teleop.step(dt, this.held);
+
+    this.applyTargets();
+
+    // Advance physics (with gravity compensation) by the real elapsed time.
+    // Physics only moves in model-timestep steps, so carry the target time
+    // across frames to keep the fractional remainder.
+    this.simTarget = (this.simTarget ?? this.mjData.time) + dt;
+    while (this.mjData.time < this.simTarget) {
+      this.controller.applyGravityComp(this.mjData);
+      mujoco.mj_step(this.mjModel, this.mjData);
+    }
+
+    // Sync MuJoCo scene into three.js.
+    mujoco.mjv_updateScene(
+      this.mjModel,
+      this.mjData,
+      this.mjvOption,
+      this.mjvPerturb,
+      this.mjvCamera,
+      mujoco.mjtCatBit.mjCAT_ALL.value,
+      this.mjvScene,
+    );
+
+    const geoms = this.mjvScene.geoms;
+    const n = geoms.size();
+    for (let i = 0; i < n; i++) {
+      const g = geoms.get(i);
+      let mesh = this.meshes[i];
+      if (!mesh) {
+        // DoubleSide: mirrored meshes (scale="1 -1 1") have flipped winding
+        const material = new THREE.MeshPhongMaterial({
+          side: THREE.DoubleSide,
+        });
+        mesh = new THREE.Mesh(this.getBufferGeometry(g), material);
+        this.meshes.push(mesh);
+        this.scene.add(mesh);
+      }
+      mesh.visible = true;
+      mesh.material.color.setRGB(g.rgba[0], g.rgba[1], g.rgba[2]);
+      mesh.material.opacity = g.rgba[3];
+      mesh.material.transparent = g.rgba[3] < 1;
+      if (
+        g.objtype === mujoco.mjtObj.mjOBJ_GEOM.value &&
+        this.transparentGeomIds.has(g.objid)
+      ) {
+        mesh.material.opacity = 0.15;
+        mesh.material.transparent = true;
+        mesh.material.depthWrite = false;
+      } else {
+        mesh.material.depthWrite = true;
+      }
+      mesh.matrixAutoUpdate = false;
+      mesh.matrix.set(
+        g.mat[0],
+        g.mat[1],
+        g.mat[2],
+        g.pos[0],
+        g.mat[3],
+        g.mat[4],
+        g.mat[5],
+        g.pos[1],
+        g.mat[6],
+        g.mat[7],
+        g.mat[8],
+        g.pos[2],
+        0,
+        0,
+        0,
+        1,
+      );
+      mesh.matrixWorldNeedsUpdate = true;
+      g.delete();
+    }
+    for (let i = n; i < this.meshes.length; i++) this.meshes[i].visible = false;
+    geoms.delete();
+
+    this.updateStatus();
+  }
+
+  updateStatus() {
+    const lines = [`speed scale: ${this.teleop.speedScale.toFixed(2)}x`];
+    for (const side of SIDES) {
+      const { pos, quat } = this.targets[side];
+      const { errorP, errorR } = this.controller.arms[side].poseError(
+        this.mjData,
+        pos,
+        quat,
+      );
+      lines.push(
+        `${side.padEnd(5)} error: ${(Math.hypot(...errorP) * 1000).toFixed(1).padStart(6)} mm  ` +
+          `${((Math.hypot(...errorR) * 180) / Math.PI).toFixed(1).padStart(5)} deg`,
+      );
+    }
+    // The values are quantized by toFixed, so while settled the text is
+    // stable: skip the DOM write (and its style invalidation) entirely.
+    const text = lines.join("\n");
+    if (text === this.lastStatus) return;
+    this.lastStatus = text;
+    this.statusElement.textContent = text;
+  }
+
+  run() {
+    let last = null;
+    const animate = (now) => {
+      // requestAnimationFrame pauses in background tabs: clamp dt so that
+      // returning to the tab does not fast-forward all the missed time in
+      // one frame.
+      const dt = last === null ? 0 : Math.min((now - last) / 1000, 0.1);
+      last = now;
+      try {
+        this.update(dt);
+        this.renderer.render(this.scene, this.camera);
+      } catch (e) {
+        // Stop the loop and rethrow: a swallowed error would repeat at 60 fps
+        // with a frozen scene and would never reach pageerror listeners.
+        this.statusElement.textContent = `error: ${e.message ?? e}`;
+        throw e;
+      }
+      requestAnimationFrame(animate);
+    };
+    requestAnimationFrame(animate);
+  }
+}
+
+// --- Keyboard -------------------------------------------------------------
+function setupKeyboard(app) {
+  window.addEventListener("keydown", (event) => {
+    if (event.ctrlKey || event.altKey || event.metaKey) return;
+    const key = event.key.toLowerCase();
+    if (key === RESET_KEY) {
+      app.reset();
+      event.preventDefault();
+    } else if (SPEED_UP_KEYS.includes(key)) {
+      app.teleop.scaleSpeed(1.25);
+    } else if (SPEED_DOWN_KEYS.includes(key)) {
+      app.teleop.scaleSpeed(1 / 1.25);
+    } else if (KEYMAP[key]) {
+      app.held.add(key);
+      event.preventDefault();
+    }
+  });
+  // TODO: event.key changes with Shift ('.' releases as '>'), so a KEYMAP
+  // punctuation key (';' ',' '.' '/') released while Shift is down — easy to
+  // hit, since raising the speed with '+' is Shift+'=' — stays in the held
+  // set and keeps driving the arm until the window blurs. Switch keydown and
+  // keyup to a shared event.code -> KEYMAP-character translation.
+  window.addEventListener("keyup", (event) => {
+    app.held.delete(event.key.toLowerCase());
+  });
+  // Losing focus releases every held key: an unwatched tab never keeps moving.
+  window.addEventListener("blur", () => app.held.clear());
+}
+
+async function main() {
+  mujoco = await loadMuJoCo();
+  const app = new App();
+  window.__app = app; // for tests and console debugging
+
+  // The scene list lives with the models: v2/scenes.json.
+  const { default: defaultScene, scenes } = await (
+    await fetchModelFile("scenes.json")
+  ).json();
+  const select = document.getElementById("scene-select");
+  for (const scene of scenes) {
+    const option = document.createElement("option");
+    option.value = scene;
+    option.textContent = scene;
+    select.appendChild(option);
+  }
+  select.value = defaultScene;
+  // Disabled until the initial load finishes: loadScene must not run twice
+  // concurrently (the loser's WASM objects would leak undeleted).
+  select.disabled = true;
+  select.onchange = async () => {
+    select.disabled = true;
+    document.getElementById("status").textContent = "loading…";
+    try {
+      await app.loadScene(select.value);
+    } catch (e) {
+      console.error("Scene load failed:", e);
+      app.statusElement.textContent = `load failed: ${e.message ?? e}`;
+    } finally {
+      select.disabled = false;
+    }
+  };
+
+  try {
+    await app.loadScene(defaultScene);
+  } catch (e) {
+    // Keep going: the rest of the UI must still be wired so that another
+    // scene can be picked from the dropdown.
+    console.error("Scene load failed:", e);
+    app.statusElement.textContent = `load failed: ${e.message ?? e}`;
+  }
+  select.disabled = false;
+  setupKeyboard(app);
+  document.getElementById("help").textContent = HELP_TEXT;
+  document.getElementById("reset-button").onclick = () => app.reset();
+  app.run();
+}
+main();

--- a/web/model-vfs.js
+++ b/web/model-vfs.js
@@ -1,0 +1,84 @@
+// Copyright 2026 Enactic, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Load a scene and everything it references into an MjVFS, mirroring the v2
+// directory layout: sub-models (file="....xml") recurse, mesh assets resolve
+// against each XML's own meshdir. readFile abstracts the byte source and
+// DOMParserImpl the XML parser (fetch + the native DOMParser in the browser,
+// fs + @xmldom/xmldom in the Node tests), so both sides load models by
+// exactly the same rules.
+export async function buildVFS(mujoco, scenePath, readFile, DOMParserImpl) {
+  const vfs = new mujoco.MjVFS();
+  const seen = new Set();
+  const assets = [];
+  const norm = (p) => {
+    const out = [];
+    for (const part of p.split("/")) {
+      if (part === "" || part === ".") continue;
+      if (part === "..") out.pop();
+      else out.push(part);
+    }
+    return out.join("/");
+  };
+  const addXML = async (path) => {
+    if (seen.has(path)) return;
+    seen.add(path);
+    const bytes = await readFile(path);
+    const text = new TextDecoder().decode(bytes);
+    vfs.addBuffer(path, bytes);
+    const dir = path.includes("/")
+      ? path.slice(0, path.lastIndexOf("/") + 1)
+      : "";
+    const doc = new DOMParserImpl().parseFromString(text, "text/xml");
+    const elements = doc.getElementsByTagName("*");
+    let meshdir = "";
+    const refs = [];
+    for (let i = 0; i < elements.length; i++) {
+      meshdir ||= elements[i].getAttribute("meshdir") ?? "";
+      const f = elements[i].getAttribute("file");
+      if (f) refs.push([elements[i].tagName, f]);
+    }
+    for (const [tag, f] of refs) {
+      if (tag === "model") {
+        await addXML(norm(dir + f));
+      } else if (tag === "mesh") {
+        const p = norm(dir + (meshdir ? `${meshdir}/` : "") + f);
+        if (!seen.has(p)) {
+          seen.add(p);
+          assets.push(p);
+        }
+      } else {
+        // Other file-based assets (texture, hfield, skin, ...) resolve
+        // against texturedir/assetdir, which this walker does not implement:
+        // fail with the reason instead of silently registering the file
+        // under a wrong, meshdir-relative VFS path.
+        throw new Error(
+          `${path}: unsupported file reference <${tag} file="${f}">`,
+        );
+      }
+    }
+  };
+  try {
+    await addXML(scenePath);
+    await Promise.all(
+      assets.map(async (p) => {
+        vfs.addBuffer(p, await readFile(p));
+      }),
+    );
+  } catch (e) {
+    vfs.delete(); // a half-built VFS would otherwise leak in the WASM heap
+    throw e;
+  }
+  return vfs;
+}

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,0 +1,99 @@
+{
+  "name": "openarm-mujoco-web-test",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "openarm-mujoco-web-test",
+      "version": "0.1.0",
+      "license": "Apache-2.0",
+      "devDependencies": {
+        "@mujoco/mujoco": "^3.12.0",
+        "@playwright/test": "^1.62.1",
+        "@xmldom/xmldom": "^0.9.12",
+        "three": "^0.185.1"
+      }
+    },
+    "node_modules/@mujoco/mujoco": {
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/@mujoco/mujoco/-/mujoco-3.12.0.tgz",
+      "integrity": "sha512-MPBSdhD7XsVkKD2owRlzf2mZzd8Qiz7v3zK9MaPc6X7ZS7LdBpQ5bgmdSrvXy6AsKHGlSocWRP9UmdV/I5+cZA==",
+      "dev": true
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+      "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
+      "dev": true,
+      "dependencies": {
+        "playwright": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@xmldom/xmldom": {
+      "version": "0.9.12",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.12.tgz",
+      "integrity": "sha512-5AXjrcMClTryPe9LgZrygpB1lj7s0S9E0+W+AHaVKAVyHanafK86iPSvG5xHVSp/jC+VH1UXu0TAEmY279xH7A==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.6"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "dev": true,
+      "dependencies": {
+        "playwright-core": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "dev": true,
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/three": {
+      "version": "0.185.1",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.185.1.tgz",
+      "integrity": "sha512-5aojFCXKwnjBRZvUnt3WFfEcvUJgkN5LlijRFN95hMy8WVkG4I0QNcJE+OuWvuJ0bOdStrbfXn0pkd6/QyiAlg==",
+      "dev": true
+    }
+  }
+}

--- a/web/package.json
+++ b/web/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "openarm-mujoco-web-test",
+  "version": "0.1.0",
+  "description": "Tests for OpenArm MuJoCo Web; the page itself runs without npm (three and @mujoco/mujoco come from the jsDelivr CDN)",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "node --test test-ik.mjs test-teleop.mjs test-scenes.mjs",
+    "test:browser": "playwright test",
+    "serve": "node serve.mjs"
+  },
+  "author": "Enactic, Inc.",
+  "license": "Apache-2.0",
+  "devDependencies": {
+    "@mujoco/mujoco": "^3.12.0",
+    "@playwright/test": "^1.62.1",
+    "@xmldom/xmldom": "^0.9.12",
+    "three": "^0.185.1"
+  }
+}

--- a/web/playwright.config.js
+++ b/web/playwright.config.js
@@ -1,0 +1,32 @@
+// Copyright 2026 Enactic, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { defineConfig } from "@playwright/test";
+
+export default defineConfig({
+  testMatch: "*.spec.mjs",
+  timeout: 120_000,
+  use: {
+    baseURL: "http://localhost:8080",
+    screenshot: "only-on-failure",
+    trace: "on-first-retry",
+    // headless WebGL needs the software rasterizer
+    launchOptions: { args: ["--enable-unsafe-swiftshader"] },
+  },
+  webServer: {
+    command: "node serve.mjs",
+    url: "http://localhost:8080/",
+    reuseExistingServer: true,
+  },
+});

--- a/web/serve.mjs
+++ b/web/serve.mjs
@@ -1,0 +1,72 @@
+// Copyright 2026 Enactic, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import fs from "node:fs/promises";
+// Minimal static file server for OpenArm MuJoCo Web — a node:http stand-in
+// for `python3 -m http.server` with no dependencies. Serves the repository
+// root (one level above web/) so the top-level index.html, web/*.js, and the
+// v2/ model files are all reachable. Run with: node serve.mjs [port]
+import http from "node:http";
+import path from "node:path";
+
+const ROOT = path.resolve(import.meta.dirname, "..");
+const PORT = Number(process.argv[2] ?? process.env.PORT ?? 8080);
+
+// Module scripts are MIME-checked by browsers, so .js/.mjs must be
+// text/javascript. Everything else here is served for completeness; fetch()
+// of model assets (.xml, .stl, ...) does not care about the type.
+const MIME = {
+  ".html": "text/html; charset=utf-8",
+  ".js": "text/javascript; charset=utf-8",
+  ".mjs": "text/javascript; charset=utf-8",
+  ".css": "text/css; charset=utf-8",
+  ".json": "application/json",
+  ".xml": "application/xml",
+  ".wasm": "application/wasm",
+  ".png": "image/png",
+  ".jpg": "image/jpeg",
+  ".svg": "image/svg+xml",
+  ".ico": "image/x-icon",
+  ".md": "text/markdown; charset=utf-8",
+};
+
+const server = http.createServer(async (req, res) => {
+  const url = new URL(req.url, "http://localhost");
+  let filePath = path.normalize(
+    path.join(ROOT, decodeURIComponent(url.pathname)),
+  );
+  if (!filePath.startsWith(ROOT + path.sep) && filePath !== ROOT) {
+    res.writeHead(403).end("Forbidden");
+    return;
+  }
+  try {
+    if ((await fs.stat(filePath)).isDirectory()) {
+      filePath = path.join(filePath, "index.html");
+    }
+    const body = await fs.readFile(filePath);
+    res.writeHead(200, {
+      "content-type":
+        MIME[path.extname(filePath).toLowerCase()] ??
+        "application/octet-stream",
+      "content-length": body.length,
+    });
+    res.end(body);
+  } catch {
+    res.writeHead(404).end("Not Found");
+  }
+});
+
+server.listen(PORT, () => {
+  console.log(`Serving ${ROOT} at http://localhost:${PORT}/`);
+});

--- a/web/teleop.js
+++ b/web/teleop.js
@@ -1,0 +1,147 @@
+// Copyright 2026 Enactic, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Pose integration for keyboard teleoperation, ported from
+// dora-openarm-keyboard (src/dora_openarm_keyboard/teleop.py).
+//
+// Held keys are read as velocities: each step() advances the target pose by
+// speed * scale * dt along every axis whose key is down. Orientation is
+// integrated in the tool frame (r_new = r_cur * delta), which keeps roll,
+// pitch and yaw meaningful relative to the gripper rather than the world.
+import { eulerZYXToQuat, quatMul } from "./ik.js";
+import { ANGULAR, GRIP, KEYMAP, LEFT, LINEAR, RIGHT } from "./keymap.js";
+
+// End-effector home pose in the arm_origin frame, identical to
+// dora-openarm-keyboard's defaults (the scene's `home` keyframe).
+export const DEFAULT_HOME = {
+  [LEFT]: [0.216, 0.1535, -0.22],
+  [RIGHT]: [0.216, -0.1535, -0.22],
+};
+const DEFAULT_HOME_RPY_DEG = [0, -90, 0];
+
+const DEFAULT_LINEAR_SPEED = 0.05; // m/s
+const DEFAULT_ANGULAR_SPEED = 0.5; // rad/s
+const DEFAULT_GRIP_SPEED = 2.0; // fraction/s
+
+const DEFAULT_POS_MIN = [-0.8, -0.8, -0.8];
+const DEFAULT_POS_MAX = [0.8, 0.8, 0.8];
+
+const MIN_SPEED_SCALE = 0.1;
+const MAX_SPEED_SCALE = 10.0;
+
+function rotvecToQuat(v) {
+  const angle = Math.hypot(...v);
+  if (angle < 1e-12) return [1, 0, 0, 0];
+  const s = Math.sin(angle / 2) / angle;
+  return [Math.cos(angle / 2), v[0] * s, v[1] * s, v[2] * s];
+}
+
+class ArmState {
+  constructor(homePos, homeQuat) {
+    this.setHome(homePos, homeQuat);
+    this.reset();
+  }
+
+  // Redefine the home pose, e.g. from a scene's keyframe, and return to it.
+  setHome(homePos, homeQuat) {
+    this.homePos = [...homePos];
+    this.homeQuat = [...homeQuat];
+    this.reset();
+  }
+
+  reset() {
+    this.pos = [...this.homePos];
+    this.quat = [...this.homeQuat];
+    this.grip = 0.0; // 0 = fully open, 1 = fully closed
+  }
+}
+
+export class TeleopState {
+  constructor() {
+    this.linearSpeed = DEFAULT_LINEAR_SPEED;
+    this.angularSpeed = DEFAULT_ANGULAR_SPEED;
+    this.gripSpeed = DEFAULT_GRIP_SPEED;
+    this.posMin = DEFAULT_POS_MIN;
+    this.posMax = DEFAULT_POS_MAX;
+    const rad = Math.PI / 180;
+    const homeQuat = eulerZYXToQuat(
+      ...DEFAULT_HOME_RPY_DEG.map((d) => d * rad),
+    );
+    this.arms = {
+      [LEFT]: new ArmState(DEFAULT_HOME[LEFT], homeQuat),
+      [RIGHT]: new ArmState(DEFAULT_HOME[RIGHT], homeQuat),
+    };
+    this.speedScale = 1.0;
+  }
+
+  scaleSpeed(factor) {
+    this.speedScale = Math.min(
+      MAX_SPEED_SCALE,
+      Math.max(MIN_SPEED_SCALE, this.speedScale * factor),
+    );
+    return this.speedScale;
+  }
+
+  reset() {
+    for (const side of [LEFT, RIGHT]) this.arms[side].reset();
+  }
+
+  // Advance both targets by one timestep of the currently held keys.
+  step(dt, heldKeys) {
+    if (dt <= 0) return;
+
+    const linear = { [LEFT]: [0, 0, 0], [RIGHT]: [0, 0, 0] };
+    const angular = { [LEFT]: [0, 0, 0], [RIGHT]: [0, 0, 0] };
+    const grip = { [LEFT]: 0, [RIGHT]: 0 };
+
+    for (const key of heldKeys) {
+      const binding = KEYMAP[key];
+      if (!binding) continue;
+      const [side, kind, axis, sign] = binding;
+      if (kind === LINEAR) linear[side][axis] += sign;
+      else if (kind === ANGULAR) angular[side][axis] += sign;
+      else if (kind === GRIP) grip[side] += sign;
+    }
+
+    for (const side of [LEFT, RIGHT]) {
+      const arm = this.arms[side];
+      for (let i = 0; i < 3; i++) {
+        arm.pos[i] = Math.min(
+          this.posMax[i],
+          Math.max(
+            this.posMin[i],
+            arm.pos[i] +
+              linear[side][i] * this.linearSpeed * this.speedScale * dt,
+          ),
+        );
+      }
+      const rotvec = angular[side].map(
+        (v) => v * this.angularSpeed * this.speedScale * dt,
+      );
+      if (rotvec.some((v) => v !== 0)) {
+        // tool frame: r_new = r_cur * delta
+        arm.quat = quatMul(arm.quat, rotvecToQuat(rotvec));
+      }
+      if (grip[side]) {
+        arm.grip = Math.min(
+          1,
+          Math.max(
+            0,
+            arm.grip + grip[side] * this.gripSpeed * this.speedScale * dt,
+          ),
+        );
+      }
+    }
+  }
+}

--- a/web/test-ik.mjs
+++ b/web/test-ik.mjs
@@ -1,0 +1,101 @@
+// Copyright 2026 Enactic, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import assert from "node:assert/strict";
+// Headless test: drive OpenArm end effectors by pose (position + orientation)
+// instead of qpos, using the PoseController from ik.js on the MuJoCo WASM
+// bindings, in the v2 cell scene. Run with: node --test test-ik.mjs
+import { test } from "node:test";
+import loadMuJoCo from "@mujoco/mujoco";
+import { PoseController, quatMul } from "./ik.js";
+import { loadCellModel } from "./load-model.mjs";
+
+test("pose control converges on offset targets in the cell scene", async (t) => {
+  const mujoco = await loadMuJoCo();
+  const model = await loadCellModel(mujoco);
+  const data = new mujoco.MjData(model);
+  const controller = new PoseController(mujoco, model);
+  t.after(() => {
+    controller.dispose();
+    data.delete();
+    model.delete();
+  });
+  t.diagnostic(`model loaded: nq=${model.nq} nv=${model.nv} nu=${model.nu}`);
+
+  // Start from the scene's home keyframe with actuators holding it.
+  controller.startFromKeyframe(data);
+  controller.syncFrom(data);
+
+  // Pose targets: 8 cm back, 5 cm inward, 8 cm up, rotated 20 deg about z.
+  const sides = ["left", "right"];
+  const targets = {};
+  for (const side of sides) {
+    const { pos, quat } = controller.arms[side].pose(data);
+    const a = (20 * Math.PI) / 180 / 2;
+    targets[side] = {
+      pos: [
+        pos[0] - 0.08,
+        pos[1] + (side === "left" ? -0.05 : 0.05),
+        pos[2] + 0.08,
+      ],
+      quat: quatMul([Math.cos(a), 0, 0, Math.sin(a)], quat),
+    };
+  }
+
+  // Solve IK once (targets are static) and command the position actuators.
+  for (const side of sides) {
+    controller.command(data, side, targets[side].pos, targets[side].quat);
+    const { errorP, errorR } = controller.arms[side].poseError(
+      controller.ikData,
+      targets[side].pos,
+      targets[side].quat,
+    );
+    assert.ok(
+      Math.hypot(...errorP) < 0.001 && Math.hypot(...errorR) < 0.01,
+      `${side} IK solution error too large: ` +
+        `${(Math.hypot(...errorP) * 1000).toFixed(3)} mm, ` +
+        `${((Math.hypot(...errorR) * 180) / Math.PI).toFixed(3)} deg`,
+    );
+  }
+
+  // Simulate with gravity/bias compensation on the arm dofs.
+  const dt = model.opt.timestep;
+  const steps = Math.round(4.0 / dt);
+  for (let i = 0; i < steps; i++) {
+    controller.applyGravityComp(data);
+    mujoco.mj_step(model, data);
+  }
+
+  for (const side of sides) {
+    const { errorP, errorR } = controller.arms[side].poseError(
+      data,
+      targets[side].pos,
+      targets[side].quat,
+    );
+    const posErr = Math.hypot(...errorP);
+    const rotErr = Math.hypot(...errorR);
+    t.diagnostic(
+      `${side} after 4 s: pos error = ${(posErr * 1000).toFixed(2)} mm, ` +
+        `rot error = ${((rotErr * 180) / Math.PI).toFixed(2)} deg`,
+    );
+    assert.ok(
+      posErr < 0.005,
+      `${side} pos error ${(posErr * 1000).toFixed(2)} mm > 5 mm`,
+    );
+    assert.ok(
+      rotErr < 0.05,
+      `${side} rot error ${((rotErr * 180) / Math.PI).toFixed(2)} deg > ${((0.05 * 180) / Math.PI).toFixed(1)} deg`,
+    );
+  }
+});

--- a/web/test-scenes.mjs
+++ b/web/test-scenes.mjs
@@ -1,0 +1,139 @@
+// Copyright 2026 Enactic, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import assert from "node:assert/strict";
+// Headless test: every v2 scene loads through the VFS, starts at its home
+// pose without yanking, and pose control still reaches a small offset target.
+// Run with: node --test test-scenes.mjs
+import fs from "node:fs";
+import path from "node:path";
+import { test } from "node:test";
+import loadMuJoCo from "@mujoco/mujoco";
+import { DOMParser } from "@xmldom/xmldom";
+import { PoseController, poseLocalToWorld } from "./ik.js";
+import { loadSceneModel } from "./load-model.mjs";
+import { buildVFS } from "./model-vfs.js";
+import { TeleopState } from "./teleop.js";
+
+// The same scene list the app's dropdown shows.
+const { scenes: SCENES } = JSON.parse(
+  fs.readFileSync(
+    path.resolve(import.meta.dirname, "../v2/scenes.json"),
+    "utf8",
+  ),
+);
+
+const mujoco = await loadMuJoCo();
+
+test("buildVFS ignores file references inside XML comments", async () => {
+  const files = {
+    "scene.xml": `<mujoco>
+      <compiler meshdir="assets"/>
+      <!-- <geom type="mesh" file="ghost.stl"/> -->
+      <asset><mesh file="real.stl"/></asset>
+    </mujoco>`,
+    "assets/real.stl": new Uint8Array([0]),
+  };
+  const requested = [];
+  const vfs = await buildVFS(
+    mujoco,
+    "scene.xml",
+    async (p) => {
+      requested.push(p);
+      if (!(p in files)) throw new Error(`${p}: missing`);
+      const f = files[p];
+      return typeof f === "string" ? new TextEncoder().encode(f) : f;
+    },
+    DOMParser,
+  );
+  vfs.delete();
+  assert.ok(requested.includes("assets/real.stl"), "real reference is loaded");
+  assert.ok(
+    !requested.some((p) => p.includes("ghost")),
+    "commented-out reference is not loaded",
+  );
+});
+
+test("buildVFS rejects file references it cannot resolve correctly", async () => {
+  // texture/hfield/skin files resolve against texturedir/assetdir, which the
+  // walker does not implement: it must fail loudly, not fetch a wrong path.
+  const scene = `<mujoco><asset><texture name="t" file="wood.png"/></asset></mujoco>`;
+  await assert.rejects(
+    buildVFS(
+      mujoco,
+      "scene.xml",
+      async () => new TextEncoder().encode(scene),
+      DOMParser,
+    ),
+    /unsupported file reference <texture file="wood\.png">/,
+  );
+});
+
+for (const scene of SCENES) {
+  test(scene, async (t) => {
+    const model = await loadSceneModel(mujoco, scene);
+    const data = new mujoco.MjData(model);
+    const controller = new PoseController(mujoco, model);
+    const teleop = new TeleopState();
+    t.after(() => {
+      controller.dispose();
+      data.delete();
+      model.delete();
+    });
+
+    // start from home (keyframe if present, else IK of the teleop default),
+    // exactly like the app does
+    controller.startFromHome(data, teleop);
+
+    // command the home pose + a 5 cm world-z offset on the left arm; simulate
+    teleop.arms.left.pos[2] += 0.05;
+    const dt = model.opt.timestep;
+    const stepsPerFrame = Math.max(1, Math.round(1 / 60 / dt));
+    for (let frame = 0; frame < 120; frame++) {
+      controller.applyTeleop(data, teleop, 0);
+      for (let i = 0; i < stepsPerFrame; i++) {
+        controller.applyGravityComp(data);
+        mujoco.mj_step(model, data);
+      }
+    }
+
+    const o = controller.originPose(data);
+    const tL = poseLocalToWorld(o, teleop.arms.left.pos, teleop.arms.left.quat);
+    const { errorP } = controller.arms.left.poseError(data, tL.pos, tL.quat);
+    const tR = poseLocalToWorld(
+      o,
+      teleop.arms.right.pos,
+      teleop.arms.right.quat,
+    );
+    const { errorP: errorPR } = controller.arms.right.poseError(
+      data,
+      tR.pos,
+      tR.quat,
+    );
+    const error = Math.hypot(...errorP);
+    const errorR = Math.hypot(...errorPR);
+    t.diagnostic(
+      `nq=${model.nq} nkey=${model.nkey} lifter=${controller.lifterActId >= 0 ? "y" : "n"} ` +
+        `left error=${(error * 1000).toFixed(1)}mm right error=${(errorR * 1000).toFixed(1)}mm`,
+    );
+    assert.ok(
+      error < 0.01,
+      `left error ${(error * 1000).toFixed(1)} mm > 10 mm`,
+    );
+    assert.ok(
+      errorR < 0.01,
+      `right error ${(errorR * 1000).toFixed(1)} mm > 10 mm`,
+    );
+  });
+}

--- a/web/test-teleop.mjs
+++ b/web/test-teleop.mjs
@@ -1,0 +1,220 @@
+// Copyright 2026 Enactic, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import assert from "node:assert/strict";
+// Headless test of keyboard teleoperation in the v2 cell scene: TeleopState
+// integration semantics (ported from dora-openarm-keyboard) and the full
+// pipeline down to physics — held keys -> arm_origin-frame pose target ->
+// world transform -> IK -> actuators -> end effector moves.
+// Run with: node --test test-teleop.mjs
+import { after, before, describe, it } from "node:test";
+import loadMuJoCo from "@mujoco/mujoco";
+import { PoseController, poseLocalToWorld, quatError } from "./ik.js";
+import { loadCellModel } from "./load-model.mjs";
+import { DEFAULT_HOME, TeleopState } from "./teleop.js";
+
+const near = (a, b, tol) => Math.abs(a - b) < tol;
+
+// The its of each describe run in order and share state on purpose: they
+// replay one continuous teleop session, each checking the next step.
+describe("TeleopState", () => {
+  const t = new TeleopState();
+
+  it("hold W for 1 s moves left +x by linear_speed (0.05 m)", () => {
+    for (let i = 0; i < 60; i++) t.step(1 / 60, new Set(["w"]));
+    assert.ok(near(t.arms.left.pos[0], DEFAULT_HOME.left[0] + 0.05, 1e-9));
+  });
+
+  it("right arm is unaffected by W", () => {
+    assert.ok(near(t.arms.right.pos[0], DEFAULT_HOME.right[0], 1e-12));
+  });
+
+  it("speed scale steps by x1.25 and clamps to [0.1, 10]", () => {
+    t.scaleSpeed(1.25);
+    assert.ok(near(t.speedScale, 1.25, 1e-12));
+    for (let i = 0; i < 100; i++) t.scaleSpeed(1.25);
+    assert.ok(near(t.speedScale, 10, 1e-12), "clamped at 10");
+    for (let i = 0; i < 100; i++) t.scaleSpeed(1 / 1.25);
+    assert.ok(near(t.speedScale, 0.1, 1e-12), "clamped at 0.1");
+    t.speedScale = 1;
+  });
+
+  it("hold Q for 1 s yaws the left tool 0.5 rad about the tool z axis", () => {
+    // Home orientation is pitch -90 deg, so tool z is not world z: the
+    // rotation axis expressed in the parent frame must be along x.
+    const before = [...t.arms.left.quat];
+    for (let i = 0; i < 60; i++) t.step(1 / 60, new Set(["q"]));
+    const error = quatError(before, t.arms.left.quat);
+    assert.ok(
+      near(Math.hypot(...error), 0.5, 1e-6),
+      `got ${Math.hypot(...error).toFixed(4)}`,
+    );
+    const axis = error.map((v) => v / Math.hypot(...error));
+    assert.ok(
+      near(Math.abs(axis[0]), 1, 1e-3),
+      `axis ${axis.map((v) => v.toFixed(3))}`,
+    );
+  });
+
+  it("grip integrates, clamps at 1, and V reopens", () => {
+    for (let i = 0; i < 60; i++) t.step(1 / 60, new Set(["g"]));
+    assert.ok(near(t.arms.left.grip, 1, 1e-9), "G closes to 1 (clamped)");
+    for (let i = 0; i < 6; i++) t.step(1 / 60, new Set(["v"]));
+    assert.ok(near(t.arms.left.grip, 0.8, 1e-9), "V reopens");
+  });
+
+  it("reset returns home", () => {
+    t.reset();
+    assert.ok(near(t.arms.left.pos[0], DEFAULT_HOME.left[0], 1e-12));
+    assert.equal(t.arms.left.grip, 0);
+  });
+
+  it("position clamps to the workspace bound", () => {
+    for (let i = 0; i < 60 * 60; i++) t.step(1 / 60, new Set(["r"]));
+    assert.ok(near(t.arms.left.pos[2], 0.8, 1e-9));
+    t.reset();
+  });
+});
+
+describe("full pipeline in the cell scene", () => {
+  let mujoco, model, data, controller, teleop, defaultHome;
+  let lifterHeight = 0;
+  let start, left;
+
+  const simulate = (frames, held) => {
+    const dt = model.opt.timestep;
+    const stepsPerFrame = Math.round(1 / 60 / dt);
+    for (let frame = 0; frame < frames; frame++) {
+      teleop.step(1 / 60, held);
+      controller.applyTeleop(data, teleop, lifterHeight);
+      for (let i = 0; i < stepsPerFrame; i++) {
+        controller.applyGravityComp(data);
+        mujoco.mj_step(model, data);
+      }
+    }
+  };
+
+  before(async () => {
+    mujoco = await loadMuJoCo();
+    model = await loadCellModel(mujoco);
+    data = new mujoco.MjData(model);
+    controller = new PoseController(mujoco, model);
+    teleop = new TeleopState();
+
+    // dora-openarm-keyboard's default home target, snapshotted before
+    // startFromHome overwrites teleop's home with the measured keyframe pose
+    defaultHome = {
+      pos: [...teleop.arms.left.pos],
+      quat: [...teleop.arms.left.quat],
+    };
+    controller.startFromHome(data, teleop); // like the app does
+  });
+
+  after(() => {
+    controller.dispose();
+    data.delete();
+    model.delete();
+  });
+
+  it("cell scene has a lifter", () => {
+    assert.ok(controller.lifterActId >= 0);
+  });
+
+  it("home keyframe matches the default teleop home pose in the arm_origin frame", () => {
+    const origin = controller.originPose(data);
+    const homeWorld = poseLocalToWorld(
+      origin,
+      defaultHome.pos,
+      defaultHome.quat,
+    );
+    const homeError = controller.arms.left.poseError(
+      data,
+      homeWorld.pos,
+      homeWorld.quat,
+    );
+    assert.ok(
+      Math.hypot(...homeError.errorP) < 0.001 &&
+        Math.hypot(...homeError.errorR) < 0.01,
+      `${(Math.hypot(...homeError.errorP) * 1000).toFixed(2)} mm, ` +
+        `${((Math.hypot(...homeError.errorR) * 180) / Math.PI).toFixed(2)} deg`,
+    );
+  });
+
+  it("2 s of W moves the left EE +10 cm in world x, right EE stays", () => {
+    start = controller.arms.left.pose(data);
+    simulate(120, new Set(["w"]));
+    simulate(60, new Set());
+    left = controller.arms.left.pose(data);
+    const right = controller.arms.right.pose(data);
+    assert.ok(
+      near(left.pos[0], start.pos[0] + 0.1, 0.005),
+      `dx = ${(left.pos[0] - start.pos[0]).toFixed(4)}`,
+    );
+    assert.ok(
+      near(left.pos[1], start.pos[1], 0.005) &&
+        near(left.pos[2], start.pos[2], 0.005),
+      "left EE y/z unchanged",
+    );
+    assert.ok(
+      near(right.pos[0], start.pos[0], 0.005),
+      "right EE stays at home",
+    );
+  });
+
+  it("lifter raises the EE while it keeps tracking the arm_origin-frame target", () => {
+    // raise the lifter 10 cm: both EEs ride along in world z, targets
+    // unchanged in the arm_origin frame
+    lifterHeight = 0.1;
+    simulate(180, new Set());
+    const lifted = controller.arms.left.pose(data);
+    assert.ok(
+      near(lifted.pos[2], left.pos[2] + 0.1, 0.005),
+      `dz = ${(lifted.pos[2] - left.pos[2]).toFixed(4)}`,
+    );
+    const o2 = controller.originPose(data);
+    const targetWorld = poseLocalToWorld(
+      o2,
+      teleop.arms.left.pos,
+      teleop.arms.left.quat,
+    );
+    const trackError = controller.arms.left.poseError(
+      data,
+      targetWorld.pos,
+      targetWorld.quat,
+    );
+    assert.ok(
+      Math.hypot(...trackError.errorP) < 0.005,
+      `${(Math.hypot(...trackError.errorP) * 1000).toFixed(2)} mm`,
+    );
+  });
+
+  it("applyTeleop skips the IK while the target is unchanged", () => {
+    controller.applyTeleop(data, teleop, lifterHeight); // warm the cache
+    const solve = controller.solve.bind(controller);
+    let calls = 0;
+    controller.solve = (...args) => {
+      calls++;
+      return solve(...args);
+    };
+    try {
+      controller.applyTeleop(data, teleop, lifterHeight);
+      assert.equal(calls, 0, "unchanged targets reuse the cached solution");
+      teleop.arms.left.pos[0] += 0.01;
+      controller.applyTeleop(data, teleop, lifterHeight);
+      assert.equal(calls, 1, "only the changed arm solves again");
+    } finally {
+      delete controller.solve;
+    }
+  });
+});


### PR DESCRIPTION
OpenArm MuJoCo Web runs the OpenArm bimanual model in the browser: the top-level index.html plus plain ES modules in web/, with physics on the official MuJoCo WASM bindings (`@mujoco/mujoco`) and rendering on three.js, both loaded from the jsDelivr npm CDN through an import map that index.html builds at runtime from web/package-lock.json — the lockfile is the single source for dependency versions. There is no build step or bundler: any static file server serving the repository root works.

The arms are driven by end-effector pose instead of qpos: PoseController (web/ik.js) runs damped-least-squares IK and feeds the model's position actuators, and TeleopState (web/teleop.js) integrates held keys with the same bindings and semantics as dora-openarm-keyboard. Scene XMLs and mesh assets are loaded from v2/ through a shared MjVFS walker (web/model-vfs.js) used by both the browser and the Node tests, and the scene list lives with the models in v2/scenes.json.

Tests are node --test suites for IK convergence, teleop semantics, and every v2 scene (web/test-*.mjs), plus a Playwright end-to-end suite (web/browser.spec.mjs) driving the real page; web/serve.mjs is a dependency-free static server for development and the Playwright webServer. .github/workflows/pages.yaml publishes index.html, web/ and v2/ to GitHub Pages: every push builds the site artifact (enabling fork previews) and push events deploy it.