### PR TITLE
preview-comment: disable from PR by Copilot and Dependabot

### DIFF
--- a/.github/workflows/preview-comment.yaml
+++ b/.github/workflows/preview-comment.yaml
@@ -15,6 +15,9 @@
 name: Preview comment
 on:
   pull_request_target:
+    branches-ignore:
+      - 'copilot/**'
+      - 'dependabot/**'
     types:
       - opened
 permissions:


### PR DESCRIPTION
They use the original repository for their feature branches. The upstream repository doesn't assume PRs from the upstream repository.